### PR TITLE
Add preliminary support for colored LogLevels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ appveyor = { repository = "daboross/fern" }
 [dependencies]
 log = "0.3"
 colored = { version = "1.5", optional = true }
-lazy_static = { version = "0.2", optional = true }
 
 [dev-dependencies]
 tempdir = "0.3"
@@ -28,4 +27,4 @@ chrono = "0.4"
 clap = "2.22"
 
 [features]
-with-colors = ["colored", "lazy_static"]
+with-colors = ["colored"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,13 @@ appveyor = { repository = "daboross/fern" }
 
 [dependencies]
 log = "0.3"
+colored = { version = "1.5", optional = true }
+lazy_static = { version = "0.2", optional = true }
 
 [dev-dependencies]
 tempdir = "0.3"
 chrono = "0.4"
 clap = "2.22"
+
+[features]
+with-colors = ["colored", "lazy_static"]

--- a/examples/colored.rs
+++ b/examples/colored.rs
@@ -1,0 +1,29 @@
+extern crate fern;
+extern crate colored;
+#[macro_use]
+extern crate log;
+extern crate chrono;
+
+use colored::Color;
+use fern::colors::ColoredLogLevel;
+use log::LogLevel;
+
+fn main() {
+    fern::Dispatch::new()
+        .chain(std::io::stdout())
+        .color(LogLevel::Error, Color::Black)
+        .format(|out, message, record| {
+            out.finish(format_args!(
+                "[{}]{} {}",
+                record.level().colored(),
+                chrono::Utc::now().format("[%Y-%m-%d %H:%M:%S]"),
+                message
+            ))
+        })
+        .apply()
+        .unwrap();
+
+    error!("hi");
+    debug!("sup");
+    warn!("oh");
+}

--- a/examples/colored.rs
+++ b/examples/colored.rs
@@ -9,13 +9,15 @@ use fern::colors::ColoredLogLevel;
 use log::LogLevel;
 
 fn main() {
+    let mut config = ColoredLogLevelConfig::default();
+    config.debug = Color::Magenta;
+
     fern::Dispatch::new()
         .chain(std::io::stdout())
-        .color(LogLevel::Error, Color::Black)
-        .format(|out, message, record| {
+        .format(move |out, message, record| {
             out.finish(format_args!(
                 "[{}]{} {}",
-                record.level().colored(),
+                config.color(record.level()),
                 chrono::Utc::now().format("[%Y-%m-%d %H:%M:%S]"),
                 message
             ))

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -1,80 +1,62 @@
 use colored::{Color, ColoredString, Colorize};
 use log::LogLevel;
-use builders::Dispatch;
-use std::sync::Mutex;
-
-lazy_static! {
-    pub static ref ERROR_COLOR: Mutex<Color> = Mutex::new(Color::Red);
-    pub static ref WARN_COLOR: Mutex<Color> = Mutex::new(Color::Yellow);
-    pub static ref INFO_COLOR: Mutex<Color> = Mutex::new(Color::Cyan);
-    pub static ref DEBUG_COLOR: Mutex<Color> = Mutex::new(Color::Green);
-    pub static ref TRACE_COLOR: Mutex<Color> = Mutex::new(Color::White);
-}
-
-impl Dispatch {
-    #[inline]
-    pub fn color(self, level: LogLevel, color: Color) -> Self {
-        match level {
-            LogLevel::Error => {
-                let mut state = ERROR_COLOR.lock().unwrap();
-
-                *state = color
-            },
-            LogLevel::Warn => {
-                let mut state = WARN_COLOR.lock().unwrap();
-
-                *state = color
-            },
-            LogLevel::Info => {
-                let mut state = INFO_COLOR.lock().unwrap();
-
-                *state = color
-            },
-            LogLevel::Debug => {
-                let mut state = DEBUG_COLOR.lock().unwrap();
-
-                *state = color
-            },
-            LogLevel::Trace => {
-                let mut state = TRACE_COLOR.lock().unwrap();
-
-                *state = color
-            },
-        }
-
-        self
-    }
-}
 
 pub trait ColoredLogLevel {
-    fn colored(&self) -> ColoredString;
-    fn as_colored(&self, color: Color) -> ColoredString;
+    fn colored(&self, color: Color) -> ColoredString;
 }
 
 fn new_colored_string(input: String, color: Color) -> ColoredString {
     let cs = ColoredString::from(input.as_str());
-
     cs.color(color)
 }
 
-fn get_color(level: &LogLevel) -> Color {
-    match *level {
-        LogLevel::Error => *ERROR_COLOR.lock().unwrap(),
-        LogLevel::Warn => *WARN_COLOR.lock().unwrap(),
-        LogLevel::Info => *INFO_COLOR.lock().unwrap(),
-        LogLevel::Debug => *DEBUG_COLOR.lock().unwrap(),
-        LogLevel::Trace => *TRACE_COLOR.lock().unwrap(),
+#[derive(Copy, Clone)]
+pub struct ColoredLogLevelConfig {
+    pub trace: Color,
+    pub error: Color,
+    pub warn: Color,
+    pub debug: Color,
+    pub info: Color,
+}
+
+impl ColoredLogLevelConfig {
+    pub fn new(trace: Color, error: Color, warn: Color, debug: Color, info: Color) -> Self {
+        ColoredLogLevelConfig {
+            trace: trace,
+            error: error,
+            warn: warn,
+            debug: debug,
+            info: info,
+        }
+    }
+
+    pub fn default() -> Self {
+        ColoredLogLevelConfig {
+            trace: Color::White,
+            error: Color::Red,
+            warn: Color::Yellow,
+            debug: Color::White,
+            info: Color::White,
+        }
+    }
+
+    pub fn color(&self, level: LogLevel) -> ColoredString {
+        level.colored(self.get_color(&level))
+    }
+
+    fn get_color(&self, level: &LogLevel) -> Color {
+        match *level {
+            LogLevel::Error => self.error,
+            LogLevel::Warn => self.warn,
+            LogLevel::Info => self.info,
+            LogLevel::Debug => self.debug,
+            LogLevel::Trace => self.trace,
+        }
     }
 }
 
 impl ColoredLogLevel for LogLevel {
-    fn colored(&self) -> ColoredString {
-        let s = format!("{:?}", self);
-
-        new_colored_string(s, get_color(self))
-    }
-
-    fn as_colored(&self, color: Color) -> ColoredString {
+    fn colored(&self, color: Color) -> ColoredString {
         let s = format!("{:?}", self);
 
         new_colored_string(s, color)

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -1,0 +1,82 @@
+use colored::{Color, ColoredString, Colorize};
+use log::LogLevel;
+use builders::Dispatch;
+use std::sync::Mutex;
+
+lazy_static! {
+    pub static ref ERROR_COLOR: Mutex<Color> = Mutex::new(Color::Red);
+    pub static ref WARN_COLOR: Mutex<Color> = Mutex::new(Color::Yellow);
+    pub static ref INFO_COLOR: Mutex<Color> = Mutex::new(Color::Cyan);
+    pub static ref DEBUG_COLOR: Mutex<Color> = Mutex::new(Color::Green);
+    pub static ref TRACE_COLOR: Mutex<Color> = Mutex::new(Color::White);
+}
+
+impl Dispatch {
+    #[inline]
+    pub fn color(self, level: LogLevel, color: Color) -> Self {
+        match level {
+            LogLevel::Error => {
+                let mut state = ERROR_COLOR.lock().unwrap();
+
+                *state = color
+            },
+            LogLevel::Warn => {
+                let mut state = WARN_COLOR.lock().unwrap();
+
+                *state = color
+            },
+            LogLevel::Info => {
+                let mut state = INFO_COLOR.lock().unwrap();
+
+                *state = color
+            },
+            LogLevel::Debug => {
+                let mut state = DEBUG_COLOR.lock().unwrap();
+
+                *state = color
+            },
+            LogLevel::Trace => {
+                let mut state = TRACE_COLOR.lock().unwrap();
+
+                *state = color
+            },
+        }
+
+        self
+    }
+}
+
+pub trait ColoredLogLevel {
+    fn colored(&self) -> ColoredString;
+    fn as_colored(&self, color: Color) -> ColoredString;
+}
+
+fn new_colored_string(input: String, color: Color) -> ColoredString {
+    let cs = ColoredString::from(input.as_str());
+
+    cs.color(color)
+}
+
+fn get_color(level: &LogLevel) -> Color {
+    match *level {
+        LogLevel::Error => *ERROR_COLOR.lock().unwrap(),
+        LogLevel::Warn => *WARN_COLOR.lock().unwrap(),
+        LogLevel::Info => *INFO_COLOR.lock().unwrap(),
+        LogLevel::Debug => *DEBUG_COLOR.lock().unwrap(),
+        LogLevel::Trace => *TRACE_COLOR.lock().unwrap(),
+    }
+}
+
+impl ColoredLogLevel for LogLevel {
+    fn colored(&self) -> ColoredString {
+        let s = format!("{:?}", self);
+
+        new_colored_string(s, get_color(self))
+    }
+
+    fn as_colored(&self, color: Color) -> ColoredString {
+        let s = format!("{:?}", self);
+
+        new_colored_string(s, color)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(missing_docs)]
+//#![deny(missing_docs)]
 #![doc(html_root_url = "https://dabo.guru/rust/fern/")]
 //! Efficient, configurable logging in Rust.
 //!
@@ -202,6 +202,11 @@
 //! [`apply`]: struct.Dispatch.html#method.apply
 //! [`log`]: doc.rust-lang.org/log/
 extern crate log;
+#[cfg(feature = "with-colors")]
+#[macro_use]
+extern crate lazy_static;
+#[cfg(feature = "with-colors")]
+extern crate colored;
 
 use std::convert::AsRef;
 use std::path::Path;
@@ -215,6 +220,8 @@ pub use errors::InitError;
 mod builders;
 mod log_impl;
 mod errors;
+#[cfg(feature = "with-colors")]
+pub mod colors;
 
 /// A type alias for a log formatter.
 pub type Formatter = Fn(FormatCallback, &fmt::Arguments, &log::LogRecord) + Sync + Send + 'static;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(missing_docs)]
+//#![deny(missing_docs)]
 #![doc(html_root_url = "https://dabo.guru/rust/fern/")]
 //! Efficient, configurable logging in Rust.
 //!
@@ -202,9 +202,6 @@
 //! [`apply`]: struct.Dispatch.html#method.apply
 //! [`log`]: doc.rust-lang.org/log/
 extern crate log;
-#[cfg(feature = "with-colors")]
-#[macro_use]
-extern crate lazy_static;
 #[cfg(feature = "with-colors")]
 extern crate colored;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//#![deny(missing_docs)]
+#![deny(missing_docs)]
 #![doc(html_root_url = "https://dabo.guru/rust/fern/")]
 //! Efficient, configurable logging in Rust.
 //!


### PR DESCRIPTION
I've added support for coloring log levels. It adds the colored and lazy_static crates as (optional) dependencies. One could possibly also modify the Dispatch struct to remove the lazy_static dependency (it's a dep of colored regardless). What else might one want to color?

Right now it doesn't compile as I haven't added documentation yet. Maybe you can give me a hint there; on how I can add it.

I'm also not sure how to exclude the colored example from the test commands. When I use them, the build fails (because the dependencies don't exist).

https://github.com/daboross/fern/issues/12