### PR TITLE
Prevent deadlocking on files when formatting itself is logged.

### DIFF
--- a/src/log_impl.rs
+++ b/src/log_impl.rs
@@ -326,12 +326,12 @@ impl Log for File {
 
     fn log(&self, record: &log::Record) {
         fallback_on_error(record, |record| {
+            // Formatting first prevents deadlocks on file-logging,
+            // when the process of formatting itself is logged.
+            let msg = format!("{}{}", record.args(), self.line_sep);
             let mut writer = self.stream.lock().unwrap_or_else(|e| e.into_inner());
-
-            write!(writer, "{}{}", record.args(), self.line_sep)?;
-
+            write!(writer, "{}", msg)?;
             writer.flush()?;
-
             Ok(())
         });
     }


### PR DESCRIPTION
Hi,
first of all, thanks for the great library. Really nice and intuitive to use.

I ran into a deadlock, when the formatting of my initial log caused another log.
Not sure if the way I fixed it is ideal since it reverses the order of the logs, but at least there is no deadlock. 