### PR TITLE
Implement a log handler which panics on messages.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,7 +215,7 @@ use std::path::Path;
 use std::fs::{File, OpenOptions};
 use std::{fmt, io};
 
-pub use builders::{Dispatch, Output};
+pub use builders::{Dispatch, Output, Panic};
 pub use log_impl::FormatCallback;
 pub use errors::InitError;
 

--- a/src/log_impl.rs
+++ b/src/log_impl.rs
@@ -59,6 +59,7 @@ pub enum Output {
     SharedDispatch(Arc<Dispatch>),
     OtherBoxed(Box<Log>),
     OtherStatic(&'static Log),
+    Panic(Panic),
 }
 
 pub struct Stdout {
@@ -85,6 +86,8 @@ pub struct Sender {
 pub struct Syslog {
     pub inner: syslog_3::Logger,
 }
+
+pub struct Panic;
 
 pub struct Null;
 
@@ -164,6 +167,7 @@ impl Log for Output {
             Output::OtherStatic(ref s) => s.enabled(metadata),
             #[cfg(feature = "syslog-3")]
             Output::Syslog(ref s) => s.enabled(metadata),
+            Output::Panic(ref s) => s.enabled(metadata),
         }
     }
 
@@ -179,6 +183,7 @@ impl Log for Output {
             Output::OtherStatic(ref s) => s.log(record),
             #[cfg(feature = "syslog-3")]
             Output::Syslog(ref s) => s.log(record),
+            Output::Panic(ref s) => s.log(record),
         }
     }
 
@@ -194,6 +199,7 @@ impl Log for Output {
             Output::OtherStatic(ref s) => s.flush(),
             #[cfg(feature = "syslog-3")]
             Output::Syslog(ref s) => s.flush(),
+            Output::Panic(ref s) => s.flush(),
         }
     }
 }
@@ -407,6 +413,18 @@ impl Log for Syslog {
             Ok(())
         });
     }
+    fn flush(&self) {}
+}
+
+impl Log for Panic {
+    fn enabled(&self, _: &log::Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &log::Record) {
+        panic!("{}", record.args());
+    }
+
     fn flush(&self) {}
 }
 

--- a/tests/panic_logging.rs
+++ b/tests/panic_logging.rs
@@ -1,0 +1,46 @@
+//! Test the functionality of panicking on error+ log messages.
+extern crate fern;
+extern crate log;
+
+use log::Level::*;
+
+mod support;
+
+use support::manual_log;
+
+#[test]
+#[should_panic(expected = "special panic message here")]
+fn test_panic_panics() {
+    let (_max_level, logger) = fern::Dispatch::new().chain(fern::Panic).into_log();
+
+    let l = &*logger;
+
+    manual_log(l, Info, "special panic message here");
+}
+
+fn warn_and_higher_panics_config() -> Box<log::Log> {
+    let (_max_level, logger) = fern::Dispatch::new()
+        .chain(
+            fern::Dispatch::new()
+                .level(log::LevelFilter::Warn)
+                .chain(fern::Panic),
+        )
+        .chain(std::io::stdout())
+        .into_log();
+    logger
+}
+
+#[test]
+fn double_chained_with_panics_no_info_panic() {
+    let l = &*warn_and_higher_panics_config();
+
+    manual_log(l, Info, "this should not panic");
+}
+
+#[test]
+#[should_panic(expected = "this should panic")]
+fn double_chained_with_panics_yes_error_panic() {
+    let l = &*warn_and_higher_panics_config();
+
+    manual_log(l, Error, "this should panic");
+}


### PR DESCRIPTION
This is a fairly simple features, so this implements the builder, log implementation, documentation and appropriate tests.

See the documentation for usage of this feature.

Fixes #20.