### PR TITLE
Add output to arbitrary Write objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ==========
 
+- Add a log handler into an arbitrary `Write` object.
+
 0.5.4 (2018-02-17)
 ==================
 


### PR DESCRIPTION
To allow logging into network sockets, memory buffers, proxies to files
with some other handling (log rotation, error recovery, …), or just
anything else.

I tried to follow the style and approach I've seen around.

For #23.