### PR TITLE
Honor formatting flags in colored log levels

### DIFF
--- a/src/colors.rs
+++ b/src/colors.rs
@@ -313,16 +313,20 @@ mod test {
                     }
                 )
             );
-            assert_eq!(
-                format!("{:^7}", "test".color(color)),
-                format!(
-                    "{:^7}",
-                    WithFgColor {
-                        text: "test",
-                        color: color,
-                    }
-                )
-            );
         }
+    }
+
+    #[test]
+    fn fg_color_respects_formatting_flags() {
+        let s = format!(
+            "{:^8}",
+            WithFgColor {
+                text: "test",
+                color: Yellow,
+            }
+        );
+        assert!(s.contains("  test  "));
+        assert!(!s.contains("   test  "));
+        assert!(!s.contains("  test   "));
     }
 }

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -91,7 +91,10 @@ where
     T: fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "\x1B[{}m{}\x1B[0m", self.color.to_fg_str(), self.text)
+        write!(f, "\x1B[{}m", self.color.to_fg_str())?;
+        fmt::Display::fmt(&self.text, f)?;
+        write!(f, "\x1B[0m")?;
+        Ok(())
     }
 }
 
@@ -304,6 +307,16 @@ mod test {
                 format!("{}", "test".color(color)),
                 format!(
                     "{}",
+                    WithFgColor {
+                        text: "test",
+                        color: color,
+                    }
+                )
+            );
+            assert_eq!(
+                format!("{:^7}", "test".color(color)),
+                format!(
+                    "{:^7}",
                     WithFgColor {
                         text: "test",
                         color: color,


### PR DESCRIPTION
Makes stuff like the following work as expected:

```rust
format!("{:>5}", colors.color(level))
```

by making `WithFgColor` properly delegate to `Display::fmt` rather than formatting its text via `"{}"`.