### PR TITLE
Don't attempt to use syslog on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ coveralls = { repository = "daboross/fern" }
 [dependencies]
 log = { version = "0.4", features = ["std"] }
 colored = { version = "1.5", optional = true }
+
+[target."cfg(not(windows))".dependencies]
 syslog3 = { version = "3", optional = true }
 syslog = { version = "4", optional = true }
 

--- a/src/builders.rs
+++ b/src/builders.rs
@@ -4,16 +4,16 @@ use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 use std::{cmp, fmt, fs, io};
 
-#[cfg(feature = "syslog-4")]
+#[cfg(all(not(windows), feature = "syslog-4"))]
 use std::collections::HashMap;
 
 use log::{self, Log};
 
 use {log_impl, Filter, FormatCallback, Formatter};
 
-#[cfg(feature = "syslog-3")]
+#[cfg(all(not(windows), feature = "syslog-3"))]
 use syslog_3;
-#[cfg(feature = "syslog-4")]
+#[cfg(all(not(windows), feature = "syslog-4"))]
 use {Syslog4Rfc3164Logger, Syslog4Rfc5424Logger};
 
 /// The base dispatch logger.
@@ -465,19 +465,19 @@ impl Dispatch {
                         line_sep: line_sep,
                     }))
                 }
-                #[cfg(feature = "syslog-3")]
+                #[cfg(all(not(windows), feature = "syslog-3"))]
                 OutputInner::Syslog3(log) => {
                     max_child_level = log::LevelFilter::Trace;
                     Some(log_impl::Output::Syslog3(log_impl::Syslog3 { inner: log }))
                 }
-                #[cfg(feature = "syslog-4")]
+                #[cfg(all(not(windows), feature = "syslog-4"))]
                 OutputInner::Syslog4Rfc3164(logger) => {
                     max_child_level = log::LevelFilter::Trace;
                     Some(log_impl::Output::Syslog4Rfc3164(log_impl::Syslog4Rfc3164 {
                         inner: Mutex::new(logger),
                     }))
                 }
-                #[cfg(feature = "syslog-4")]
+                #[cfg(all(not(windows), feature = "syslog-4"))]
                 OutputInner::Syslog4Rfc5424 { logger, transform } => {
                     max_child_level = log::LevelFilter::Trace;
                     Some(log_impl::Output::Syslog4Rfc5424(log_impl::Syslog4Rfc5424 {
@@ -632,13 +632,13 @@ enum OutputInner {
     /// Passes all messages to other logger.
     OtherStatic(&'static Log),
     /// Passes all messages to the syslog.
-    #[cfg(feature = "syslog-3")]
+    #[cfg(all(not(windows), feature = "syslog-3"))]
     Syslog3(syslog_3::Logger),
     /// Passes all messages to the syslog.
-    #[cfg(feature = "syslog-4")]
+    #[cfg(all(not(windows), feature = "syslog-4"))]
     Syslog4Rfc3164(Syslog4Rfc3164Logger),
     /// Sends all messages through the transform then passes to the syslog.
-    #[cfg(feature = "syslog-4")]
+    #[cfg(all(not(windows), feature = "syslog-4"))]
     Syslog4Rfc5424 {
         logger: Syslog4Rfc5424Logger,
         transform: Box<
@@ -792,7 +792,7 @@ impl From<Sender<String>> for Output {
     }
 }
 
-#[cfg(feature = "syslog-3")]
+#[cfg(all(not(windows), feature = "syslog-3"))]
 impl From<syslog_3::Logger> for Output {
     /// Creates an output logger which writes all messages to the given syslog
     /// output.
@@ -806,7 +806,7 @@ impl From<syslog_3::Logger> for Output {
     }
 }
 
-#[cfg(feature = "syslog-3")]
+#[cfg(all(not(windows), feature = "syslog-3"))]
 impl From<Box<syslog_3::Logger>> for Output {
     /// Creates an output logger which writes all messages to the given syslog
     /// output.
@@ -825,7 +825,7 @@ impl From<Box<syslog_3::Logger>> for Output {
     }
 }
 
-#[cfg(feature = "syslog-4")]
+#[cfg(all(not(windows), feature = "syslog-4"))]
 impl From<Syslog4Rfc3164Logger> for Output {
     /// Creates an output logger which writes all messages to the given syslog.
     ///
@@ -1036,7 +1036,7 @@ impl Output {
     /// This requires the `"syslog-4"` feature.
     ///
     /// [the rfc]: https://tools.ietf.org/html/rfc5424
-    #[cfg(feature = "syslog-4")]
+    #[cfg(all(not(windows), feature = "syslog-4"))]
     pub fn syslog_5424<F>(logger: Syslog4Rfc5424Logger, transform: F) -> Self
     where
         F: Fn(&log::Record) -> (i32, HashMap<String, HashMap<String, String>>, String)
@@ -1168,17 +1168,17 @@ impl fmt::Debug for OutputInner {
                 .field("stream", stream)
                 .field("line_sep", line_sep)
                 .finish(),
-            #[cfg(feature = "syslog-3")]
+            #[cfg(all(not(windows), feature = "syslog-3"))]
             OutputInner::Syslog3(_) => f
                 .debug_tuple("Output::Syslog3")
                 .field(&"<unprintable syslog::Logger>")
                 .finish(),
-            #[cfg(feature = "syslog-4")]
+            #[cfg(all(not(windows), feature = "syslog-4"))]
             OutputInner::Syslog4Rfc3164 { .. } => f
                 .debug_tuple("Output::Syslog4Rfc3164")
                 .field(&"<unprintable syslog::Logger>")
                 .finish(),
-            #[cfg(feature = "syslog-4")]
+            #[cfg(all(not(windows), feature = "syslog-4"))]
             OutputInner::Syslog4Rfc5424 { .. } => f
                 .debug_tuple("Output::Syslog4Rfc5424")
                 .field(&"<unprintable syslog::Logger>")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,9 +217,9 @@
 #[cfg(feature = "colored")]
 extern crate colored;
 extern crate log;
-#[cfg(feature = "syslog-4")]
+#[cfg(all(feature = "syslog-4", not(windows)))]
 extern crate syslog as syslog_4;
-#[cfg(feature = "syslog-3")]
+#[cfg(all(feature = "syslog-3", not(windows)))]
 extern crate syslog3 as syslog_3;
 
 use std::convert::AsRef;
@@ -240,7 +240,7 @@ mod log_impl;
 
 #[cfg(feature = "colored")]
 pub mod colors;
-#[cfg(all(feature = "syslog-3", feature = "syslog-4"))]
+#[cfg(all(not(windows), feature = "syslog-3", feature = "syslog-4"))]
 pub mod syslog;
 
 pub mod meta;
@@ -255,11 +255,11 @@ pub type Formatter = Fn(FormatCallback, &fmt::Arguments, &log::Record) + Sync + 
 /// succeed - false means it should fail.
 pub type Filter = Fn(&log::Metadata) -> bool + Send + Sync + 'static;
 
-#[cfg(feature = "syslog-4")]
+#[cfg(all(feature = "syslog-4", not(windows)))]
 type Syslog4Rfc3164Logger =
     syslog_4::Logger<syslog_4::LoggerBackend, String, syslog_4::Formatter3164>;
 
-#[cfg(feature = "syslog-4")]
+#[cfg(all(feature = "syslog-4", not(windows)))]
 type Syslog4Rfc5424Logger = syslog_4::Logger<
     syslog_4::LoggerBackend,
     (i32, HashMap<String, HashMap<String, String>>, String),

--- a/src/log_impl.rs
+++ b/src/log_impl.rs
@@ -10,9 +10,9 @@ use log::{self, Log};
 
 use {Filter, Formatter};
 
-#[cfg(feature = "syslog-3")]
+#[cfg(all(not(windows), feature = "syslog-3"))]
 use syslog_3;
-#[cfg(feature = "syslog-4")]
+#[cfg(all(not(windows), feature = "syslog-4"))]
 use {syslog_4, Syslog4Rfc3164Logger, Syslog4Rfc5424Logger};
 
 pub enum LevelConfiguration {
@@ -55,11 +55,11 @@ pub enum Output {
     Stderr(Stderr),
     File(File),
     Sender(Sender),
-    #[cfg(feature = "syslog-3")]
+    #[cfg(all(not(windows), feature = "syslog-3"))]
     Syslog3(Syslog3),
-    #[cfg(feature = "syslog-4")]
+    #[cfg(all(not(windows), feature = "syslog-4"))]
     Syslog4Rfc3164(Syslog4Rfc3164),
-    #[cfg(feature = "syslog-4")]
+    #[cfg(all(not(windows), feature = "syslog-4"))]
     Syslog4Rfc5424(Syslog4Rfc5424),
     Dispatch(Dispatch),
     SharedDispatch(Arc<Dispatch>),
@@ -94,17 +94,17 @@ pub struct Writer {
     pub line_sep: Cow<'static, str>,
 }
 
-#[cfg(feature = "syslog-3")]
+#[cfg(all(not(windows), feature = "syslog-3"))]
 pub struct Syslog3 {
     pub inner: syslog_3::Logger,
 }
 
-#[cfg(feature = "syslog-4")]
+#[cfg(all(not(windows), feature = "syslog-4"))]
 pub struct Syslog4Rfc3164 {
     pub inner: Mutex<Syslog4Rfc3164Logger>,
 }
 
-#[cfg(feature = "syslog-4")]
+#[cfg(all(not(windows), feature = "syslog-4"))]
 pub struct Syslog4Rfc5424 {
     pub inner: Mutex<Syslog4Rfc5424Logger>,
     pub transform: Box<
@@ -191,11 +191,11 @@ impl Log for Output {
             Output::SharedDispatch(ref s) => s.enabled(metadata),
             Output::OtherBoxed(ref s) => s.enabled(metadata),
             Output::OtherStatic(ref s) => s.enabled(metadata),
-            #[cfg(feature = "syslog-3")]
+            #[cfg(all(not(windows), feature = "syslog-3"))]
             Output::Syslog3(ref s) => s.enabled(metadata),
-            #[cfg(feature = "syslog-4")]
+            #[cfg(all(not(windows), feature = "syslog-4"))]
             Output::Syslog4Rfc3164(ref s) => s.enabled(metadata),
-            #[cfg(feature = "syslog-4")]
+            #[cfg(all(not(windows), feature = "syslog-4"))]
             Output::Syslog4Rfc5424(ref s) => s.enabled(metadata),
             Output::Panic(ref s) => s.enabled(metadata),
             Output::Writer(ref s) => s.enabled(metadata),
@@ -212,11 +212,11 @@ impl Log for Output {
             Output::SharedDispatch(ref s) => s.log(record),
             Output::OtherBoxed(ref s) => s.log(record),
             Output::OtherStatic(ref s) => s.log(record),
-            #[cfg(feature = "syslog-3")]
+            #[cfg(all(not(windows), feature = "syslog-3"))]
             Output::Syslog3(ref s) => s.log(record),
-            #[cfg(feature = "syslog-4")]
+            #[cfg(all(not(windows), feature = "syslog-4"))]
             Output::Syslog4Rfc3164(ref s) => s.log(record),
-            #[cfg(feature = "syslog-4")]
+            #[cfg(all(not(windows), feature = "syslog-4"))]
             Output::Syslog4Rfc5424(ref s) => s.log(record),
             Output::Panic(ref s) => s.log(record),
             Output::Writer(ref s) => s.log(record),
@@ -233,11 +233,11 @@ impl Log for Output {
             Output::SharedDispatch(ref s) => s.flush(),
             Output::OtherBoxed(ref s) => s.flush(),
             Output::OtherStatic(ref s) => s.flush(),
-            #[cfg(feature = "syslog-3")]
+            #[cfg(all(not(windows), feature = "syslog-3"))]
             Output::Syslog3(ref s) => s.flush(),
-            #[cfg(feature = "syslog-4")]
+            #[cfg(all(not(windows), feature = "syslog-4"))]
             Output::Syslog4Rfc3164(ref s) => s.flush(),
-            #[cfg(feature = "syslog-4")]
+            #[cfg(all(not(windows), feature = "syslog-4"))]
             Output::Syslog4Rfc5424(ref s) => s.flush(),
             Output::Panic(ref s) => s.flush(),
             Output::Writer(ref s) => s.flush(),
@@ -480,7 +480,7 @@ impl Log for Syslog3 {
     fn flush(&self) {}
 }
 
-#[cfg(feature = "syslog-4")]
+#[cfg(all(not(windows), feature = "syslog-4"))]
 impl Log for Syslog4Rfc3164 {
     fn enabled(&self, _: &log::Metadata) -> bool {
         true
@@ -498,7 +498,7 @@ impl Log for Syslog4Rfc3164 {
     fn flush(&self) {}
 }
 
-#[cfg(feature = "syslog-4")]
+#[cfg(all(not(windows), feature = "syslog-4"))]
 impl Log for Syslog4Rfc5424 {
     fn enabled(&self, _: &log::Metadata) -> bool {
         true
@@ -569,7 +569,7 @@ fn backup_logging(record: &log::Record, error: &LogError) {
 enum LogError {
     Io(io::Error),
     Send(mpsc::SendError<String>),
-    #[cfg(feature = "syslog-4")]
+    #[cfg(all(not(windows), feature = "syslog-4"))]
     Syslog4(syslog_4::Error),
 }
 
@@ -578,7 +578,7 @@ impl fmt::Display for LogError {
         match *self {
             LogError::Io(ref e) => write!(f, "{}", e),
             LogError::Send(ref e) => write!(f, "{}", e),
-            #[cfg(feature = "syslog-4")]
+            #[cfg(all(not(windows), feature = "syslog-4"))]
             LogError::Syslog4(ref e) => write!(f, "{}", e),
         }
     }
@@ -596,7 +596,7 @@ impl From<mpsc::SendError<String>> for LogError {
     }
 }
 
-#[cfg(feature = "syslog-4")]
+#[cfg(all(not(windows), feature = "syslog-4"))]
 impl From<syslog_4::Error> for LogError {
     fn from(error: syslog_4::Error) -> Self {
         LogError::Syslog4(error)


### PR DESCRIPTION
There are two issues that don't play well with each other:

- The syslog crate doesn't build on Windows: https://github.com/Geal/rust-syslog/issues/43
- It's not possible to selectively enable/disable cargo features on a per-target basis: https://github.com/rust-lang/cargo/issues/1197

Combining those two issues means that it's not currently possible to write an application that is portable to Windows and uses the syslog feature on UNIX. Considering the lack of activity on both issues, I don't expect either of those will be fixed soon.

This PR provides a workaround: It allows the "syslog" features to be enabled on Windows, but doesn't actually pull in the syslog crate in that case. It's not my favourite solution, but it does get the job done.