### PR TITLE
Fix Dispatch enabled() to check child logs

### DIFF
--- a/src/log_impl.rs
+++ b/src/log_impl.rs
@@ -317,7 +317,7 @@ impl Dispatch {
     ///
     /// This is recursive, and checks children.
     fn deep_enabled(&self, metadata: &log::Metadata) -> bool {
-        self.shallow_enabled(metadata) && self.output.iter().map(|l| l.enabled()).any()
+        self.shallow_enabled(metadata) && self.output.iter().any(|l| l.enabled(metadata))
     }
 }
 

--- a/tests/enabled_is_deep_check.rs
+++ b/tests/enabled_is_deep_check.rs
@@ -1,0 +1,24 @@
+//! See https://github.com/daboross/fern/issues/38
+extern crate fern;
+#[macro_use]
+extern crate log;
+
+#[test]
+fn ensure_enabled_is_a_deep_check() {
+    let dummy = fern::Dispatch::new()
+        .level(log::LevelFilter::Warn)
+        .chain(std::io::stdout());
+
+    let stdout = fern::Dispatch::new()
+        .level(log::LevelFilter::Info)
+        .level_for("abc", log::LevelFilter::Debug)
+        .chain(std::io::stdout());
+
+    fern::Dispatch::new()
+        .chain(stdout)
+        .chain(dummy)
+        .apply()
+        .unwrap();
+
+    assert!(!log_enabled!(log::Level::Debug));
+}


### PR DESCRIPTION
Fixes #38.

This leaves the call to enabled() in log() as a shallow check, making the assumption that log formatters will be low-cost until the log actually formats. I think this should be alright for now, but it might want to be changed later.