### PR TITLE
Update crate to Rust 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,14 +27,14 @@ colored = { version = "1.5", optional = true }
 chrono = "0.4"
 
 [target."cfg(not(windows))".dependencies]
-syslog3 = { version = "3", optional = true }
-syslog = { version = "4", optional = true }
+syslog3 = { version = "3", package = "syslog", optional = true }
+syslog4 = { version = "4", package = "syslog", optional = true }
 reopen = { version = "^0.3", optional = true }
 libc = { version = "0.2.58", optional = true }
 
 [features]
 syslog-3 = ["syslog3"]
-syslog-4 = ["syslog"]
+syslog-4 = ["syslog4"]
 reopen-03 = ["reopen", "libc"]
 meta-logging-in-format = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ name = "fern"
 version = "0.5.9"
 authors = ["David Ross <daboross@daboross.net>"]
 description = "Simple, efficient logging"
+edition = "2018"
 
 documentation = "https://docs.rs/fern/"
 repository = "https://github.com/daboross/fern"

--- a/examples/cmd-program.rs
+++ b/examples/cmd-program.rs
@@ -1,9 +1,4 @@
-extern crate chrono;
-extern crate clap;
-extern crate fern;
-#[macro_use]
-extern crate log;
-
+use log::{debug, info, trace, warn};
 use std::io;
 
 fn setup_logging(verbosity: u64) -> Result<(), fern::InitError> {

--- a/examples/colored.rs
+++ b/examples/colored.rs
@@ -1,9 +1,5 @@
-extern crate chrono;
-extern crate fern;
-#[macro_use]
-extern crate log;
-
 use fern::colors::{Color, ColoredLevelConfig};
+use log::{debug, error, warn};
 
 fn main() {
     let colors = ColoredLevelConfig::new().debug(Color::Magenta);

--- a/examples/date-based-file-log.rs
+++ b/examples/date-based-file-log.rs
@@ -1,6 +1,6 @@
 use log::{debug, info, warn};
 
-fn setup_logging() -> Result<(), Box<std::error::Error>> {
+fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
     fern::Dispatch::new()
         // by default only accept warning messages so as not to spam
         .level(log::LevelFilter::Debug)

--- a/examples/date-based-file-log.rs
+++ b/examples/date-based-file-log.rs
@@ -1,6 +1,4 @@
-extern crate fern;
-#[macro_use]
-extern crate log;
+use log::{debug, info, warn};
 
 fn setup_logging() -> Result<(), Box<std::error::Error>> {
     fern::Dispatch::new()

--- a/examples/meta-logging.rs
+++ b/examples/meta-logging.rs
@@ -2,9 +2,7 @@
 //!
 //! The example will hang if the feature is disabled, and will produce cohesive
 //! logs if it's enabled.
-extern crate fern;
-#[macro_use]
-extern crate log;
+use log::{debug, info};
 
 use std::fmt;
 

--- a/examples/pretty-colored.rs
+++ b/examples/pretty-colored.rs
@@ -6,11 +6,7 @@
 //!   line is white
 //! - when the log level is debug, the whole line is white
 //! - when the log level is trace, the whole line is gray ("bright black")
-
-extern crate chrono;
-extern crate fern;
-#[macro_use]
-extern crate log;
+use log::{debug, error, info, trace, warn};
 
 use fern::colors::{Color, ColoredLevelConfig};
 

--- a/examples/syslog.rs
+++ b/examples/syslog.rs
@@ -1,7 +1,7 @@
 use log::{debug, info, warn};
 
 #[cfg(not(windows))]
-fn setup_logging() -> Result<(), Box<std::error::Error>> {
+fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
     let syslog_fmt = syslog::Formatter3164 {
         facility: syslog::Facility::LOG_USER,
         hostname: None,

--- a/examples/syslog.rs
+++ b/examples/syslog.rs
@@ -1,8 +1,4 @@
-extern crate fern;
-#[macro_use]
-extern crate log;
-#[cfg(not(windows))]
-extern crate syslog;
+use log::{debug, info, warn};
 
 #[cfg(not(windows))]
 fn setup_logging() -> Result<(), Box<std::error::Error>> {

--- a/examples/syslog.rs
+++ b/examples/syslog.rs
@@ -1,3 +1,6 @@
+#[cfg(not(windows))]
+use syslog4 as syslog;
+
 use log::{debug, info, warn};
 
 #[cfg(not(windows))]

--- a/examples/syslog3.rs
+++ b/examples/syslog3.rs
@@ -1,9 +1,8 @@
-extern crate fern;
-#[macro_use]
-extern crate log;
 #[cfg(not(windows))]
 // This is necessary because `fern` depends on both version 3 and 4.
-extern crate syslog3 as syslog;
+use syslog3 as syslog;
+
+use log::{debug, info, warn};
 
 #[cfg(not(windows))]
 fn setup_logging() -> Result<(), fern::InitError> {

--- a/src/builders.rs
+++ b/src/builders.rs
@@ -10,13 +10,13 @@ use std::collections::HashMap;
 
 use log::{self, Log};
 
-use log_impl::DateBasedLogFileState;
-use {log_impl, Filter, FormatCallback, Formatter};
+use crate::log_impl::DateBasedLogFileState;
+use crate::{log_impl, Filter, FormatCallback, Formatter};
 
 #[cfg(all(not(windows), feature = "syslog-3"))]
-use syslog_3;
+use crate::syslog_3;
 #[cfg(all(not(windows), feature = "syslog-4"))]
-use {Syslog4Rfc3164Logger, Syslog4Rfc5424Logger};
+use crate::{Syslog4Rfc3164Logger, Syslog4Rfc5424Logger};
 #[cfg(all(not(windows), feature = "reopen-03"))]
 use reopen;
 
@@ -35,10 +35,6 @@ use reopen;
 ///
 /// ```no_run
 /// # // no_run because this creates log files.
-/// #[macro_use]
-/// extern crate log;
-/// extern crate fern;
-///
 /// use std::{fs, io};
 ///
 /// # fn setup_logger() -> Result<(), fern::InitError> {
@@ -214,9 +210,6 @@ impl Dispatch {
     /// Example usage:
     ///
     /// ```
-    /// # extern crate log;
-    /// # extern crate fern;
-    /// #
     /// # fn main() {
     /// fern::Dispatch::new()
     ///     .level(log::LevelFilter::Info)
@@ -249,9 +242,6 @@ impl Dispatch {
     /// excluded:
     ///
     /// ```
-    /// # extern crate log;
-    /// # extern crate fern;
-    /// #
     /// # fn main() {
     /// fern::Dispatch::new()
     ///     .level(log::LevelFilter::Trace)
@@ -266,9 +256,6 @@ impl Dispatch {
     /// rest of the program at info level:
     ///
     /// ```
-    /// # extern crate log;
-    /// # extern crate fern;
-    /// #
     /// fn setup_logging<T, I>(verbose_modules: T) -> Result<(), fern::InitError>
     /// where
     ///     I: AsRef<str>,
@@ -330,9 +317,6 @@ impl Dispatch {
     /// This sends error level messages to stderr and others to stdout.
     ///
     /// ```
-    /// # extern crate log;
-    /// # extern crate fern;
-    /// #
     /// # fn main() {
     /// fern::Dispatch::new()
     ///     .level(log::LevelFilter::Info)
@@ -373,9 +357,6 @@ impl Dispatch {
     /// program only opens "file.log" once.
     ///
     /// ```no_run
-    /// # extern crate log;
-    /// # extern crate fern;
-    /// #
     /// # fn setup_logger() -> Result<(), fern::InitError> {
     ///
     /// let file_out = fern::Dispatch::new()
@@ -602,9 +583,6 @@ impl Dispatch {
     /// Example usage:
     ///
     /// ```
-    /// # extern crate log;
-    /// # extern crate fern;
-    /// #
     /// # fn main() {
     /// let (min_level, log) = fern::Dispatch::new()
     ///     .level(log::LevelFilter::Info)
@@ -719,8 +697,6 @@ enum OutputInner {
 /// message is sent.
 ///
 /// ```
-/// # extern crate fern;
-/// # extern crate log;
 /// fern::Dispatch::new()
 ///     // format, etc.
 ///     .chain(std::io::stdout())
@@ -741,8 +717,6 @@ enum OutputInner {
 /// messages.
 ///
 /// ```no_run
-/// # extern crate fern;
-/// # extern crate log;
 /// fn setup_panic_logging() {
 ///     fern::Dispatch::new()
 ///         .level(log::LevelFilter::Warn)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -51,7 +51,7 @@ impl error::Error for InitError {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             InitError::Io(ref e) => Some(e),
             InitError::SetLoggerError(ref e) => Some(e),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,11 +232,11 @@ pub mod meta;
 ///
 /// As of fern `0.5`, the passed `fmt::Arguments` will always be the same as
 /// the given `log::Record`'s `.args()`.
-pub type Formatter = Fn(FormatCallback, &fmt::Arguments, &log::Record) + Sync + Send + 'static;
+pub type Formatter = dyn Fn(FormatCallback, &fmt::Arguments, &log::Record) + Sync + Send + 'static;
 
 /// A type alias for a log filter. Returning true means the record should
 /// succeed - false means it should fail.
-pub type Filter = Fn(&log::Metadata) -> bool + Send + Sync + 'static;
+pub type Filter = dyn Fn(&log::Metadata) -> bool + Send + Sync + 'static;
 
 pub use crate::builders::DateBasedLogFile;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,7 +200,7 @@
 //! [syslog]: syslog/index.html
 //! [meta]: meta/index.html
 #[cfg(all(not(windows), feature = "syslog-4"))]
-use ::syslog as syslog_4;
+use syslog4 as syslog_4;
 #[cfg(all(not(windows), feature = "syslog-3"))]
 use syslog3 as syslog_3;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,15 +12,6 @@
 //! fern = "0.5"
 //! ```
 //!
-//! Then declare both in `main.rs` or `lib.rs`:
-//!
-//! ```
-//! #[macro_use]
-//! extern crate log;
-//! extern crate fern;
-//! # fn main() {}
-//! ```
-//!
 //! # Example setup
 //!
 //! With fern, all logger configuration is done via builder-like methods on
@@ -30,11 +21,7 @@
 //! and above to both stdout and an output.log file:
 //!
 //! ```no_run
-//! extern crate fern;
-//! #[macro_use]
-//! extern crate log;
-//!
-//! extern crate chrono;
+//! use log::{debug, error, info, trace, warn};
 //!
 //! fn setup_logger() -> Result<(), fern::InitError> {
 //!     fern::Dispatch::new()
@@ -151,9 +138,7 @@
 //! crate and all libraries you depend on.
 //!
 //! ```rust
-//! # #[macro_use]
-//! # extern crate log;
-//! # extern crate fern;
+//! # use log::{debug, error, info, trace, warn};
 //!
 //! # fn setup_logger() -> Result<(), fern::InitError> {
 //! fern::Dispatch::new()
@@ -214,17 +199,10 @@
 //! [colors]: colors/index.html
 //! [syslog]: syslog/index.html
 //! [meta]: meta/index.html
-#[cfg(feature = "colored")]
-extern crate colored;
-#[cfg(all(not(windows), feature = "reopen-03"))]
-extern crate libc;
-extern crate log;
 #[cfg(all(not(windows), feature = "syslog-4"))]
-extern crate syslog as syslog_4;
+use ::syslog as syslog_4;
 #[cfg(all(not(windows), feature = "syslog-3"))]
-extern crate syslog3 as syslog_3;
-#[cfg(all(not(windows), feature = "reopen-03"))]
-extern crate reopen;
+use syslog3 as syslog_3;
 
 
 use std::convert::AsRef;
@@ -235,9 +213,9 @@ use std::{fmt, io};
 #[cfg(all(not(windows), feature = "syslog-4"))]
 use std::collections::HashMap;
 
-pub use builders::{Dispatch, Output, Panic};
-pub use errors::InitError;
-pub use log_impl::FormatCallback;
+pub use crate::builders::{Dispatch, Output, Panic};
+pub use crate::errors::InitError;
+pub use crate::log_impl::FormatCallback;
 
 mod builders;
 mod errors;
@@ -260,7 +238,7 @@ pub type Formatter = Fn(FormatCallback, &fmt::Arguments, &log::Record) + Sync + 
 /// succeed - false means it should fail.
 pub type Filter = Fn(&log::Metadata) -> bool + Send + Sync + 'static;
 
-pub use builders::DateBasedLogFile;
+pub use crate::builders::DateBasedLogFile;
 
 #[cfg(all(not(windows), feature = "syslog-4"))]
 type Syslog4Rfc3164Logger =

--- a/src/log_impl.rs
+++ b/src/log_impl.rs
@@ -1,5 +1,3 @@
-extern crate chrono;
-
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::fs::OpenOptions;
@@ -12,12 +10,12 @@ use std::collections::HashMap;
 
 use log::{self, Log};
 
-use {Filter, Formatter};
+use crate::{Filter, Formatter};
 
 #[cfg(all(not(windows), feature = "syslog-3"))]
-use syslog_3;
+use crate::syslog_3;
 #[cfg(all(not(windows), feature = "syslog-4"))]
-use {syslog_4, Syslog4Rfc3164Logger, Syslog4Rfc5424Logger};
+use crate::{syslog_4, Syslog4Rfc3164Logger, Syslog4Rfc5424Logger};
 #[cfg(all(not(windows), feature = "reopen-03"))]
 use reopen;
 

--- a/src/log_impl.rs
+++ b/src/log_impl.rs
@@ -67,8 +67,8 @@ pub enum Output {
     Syslog4Rfc5424(Syslog4Rfc5424),
     Dispatch(Dispatch),
     SharedDispatch(Arc<Dispatch>),
-    OtherBoxed(Box<Log>),
-    OtherStatic(&'static Log),
+    OtherBoxed(Box<dyn Log>),
+    OtherStatic(&'static dyn Log),
     Panic(Panic),
     Writer(Writer),
     DateBasedFileLog(DateBasedLogFile),
@@ -97,7 +97,7 @@ pub struct Sender {
 }
 
 pub struct Writer {
-    pub stream: Mutex<Box<Write + Send>>,
+    pub stream: Mutex<Box<dyn Write + Send>>,
     pub line_sep: Cow<'static, str>,
 }
 
@@ -121,7 +121,9 @@ pub struct Syslog4Rfc3164 {
 pub struct Syslog4Rfc5424 {
     pub inner: Mutex<Syslog4Rfc5424Logger>,
     pub transform: Box<
-        Fn(&log::Record) -> (i32, HashMap<String, HashMap<String, String>>, String) + Sync + Send,
+        dyn Fn(&log::Record) -> (i32, HashMap<String, HashMap<String, String>>, String)
+            + Sync
+            + Send,
     >,
 }
 

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -5,8 +5,7 @@ calls to the global logger from within their `Display` or `Debug` implementation
 Here's an example of such a structure:
 
 ```
-# #[macro_use]
-# extern crate log;
+# use log::debug;
 # use std::fmt;
 #
 struct Thing<'a>(&'a str);

--- a/src/syslog.rs
+++ b/src/syslog.rs
@@ -12,7 +12,7 @@ syslog = "4"
 To use `syslog`, simply create the log you want, and pass it into `Dispatch::chain`:
 
 ```no_run
-# fn setup_logging() -> Result<(), Box<std::error::Error>> {
+# fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
 let formatter = syslog::Formatter3164 {
     facility: syslog::Facility::LOG_USER,
     hostname: None,
@@ -49,7 +49,7 @@ The setup is very similar, except with less configuration to start the syslog lo
 
 ```rust
 # use syslog3 as syslog;
-# fn setup_logging() -> Result<(), Box<std::error::Error>> {
+# fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
 fern::Dispatch::new()
     .chain(syslog::unix(syslog::Facility::LOG_USER)?)
     .apply()?;
@@ -70,7 +70,7 @@ However, you probably will want to format messages you also send to stdout! Fort
 configuration is easy with fern:
 
 ```no_run
-# fn setup_logging() -> Result<(), Box<std::error::Error>> {
+# fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
 let syslog_formatter = syslog::Formatter3164 {
     facility: syslog::Facility::LOG_USER,
     hostname: None,
@@ -114,7 +114,7 @@ One last pattern you might want to know: creating a log target which must be exp
 in order to work.
 
 ```no_run
-# fn setup_logging() -> Result<(), Box<std::error::Error>> {
+# fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
 # let formatter = syslog::Formatter3164 {
 #     facility: syslog::Facility::LOG_USER,
 #     hostname: None,

--- a/src/syslog.rs
+++ b/src/syslog.rs
@@ -12,9 +12,6 @@ syslog = "4"
 To use `syslog`, simply create the log you want, and pass it into `Dispatch::chain`:
 
 ```no_run
-extern crate fern;
-extern crate syslog;
-
 # fn setup_logging() -> Result<(), Box<std::error::Error>> {
 let formatter = syslog::Formatter3164 {
     facility: syslog::Facility::LOG_USER,
@@ -51,11 +48,7 @@ syslog = "3"
 The setup is very similar, except with less configuration to start the syslog logger:
 
 ```rust
-extern crate fern;
-# /*
-extern crate syslog;
-# */ extern crate syslog3 as syslog;
-
+# use syslog3 as syslog;
 # fn setup_logging() -> Result<(), Box<std::error::Error>> {
 fern::Dispatch::new()
     .chain(syslog::unix(syslog::Facility::LOG_USER)?)
@@ -77,10 +70,6 @@ However, you probably will want to format messages you also send to stdout! Fort
 configuration is easy with fern:
 
 ```no_run
-# extern crate fern;
-# extern crate log;
-# extern crate syslog;
-#
 # fn setup_logging() -> Result<(), Box<std::error::Error>> {
 let syslog_formatter = syslog::Formatter3164 {
     facility: syslog::Facility::LOG_USER,
@@ -125,10 +114,6 @@ One last pattern you might want to know: creating a log target which must be exp
 in order to work.
 
 ```no_run
-# extern crate fern;
-# extern crate log;
-# extern crate syslog;
-#
 # fn setup_logging() -> Result<(), Box<std::error::Error>> {
 # let formatter = syslog::Formatter3164 {
 #     facility: syslog::Facility::LOG_USER,
@@ -152,8 +137,7 @@ With this configuration, only warning messages will get through by default. If w
 send info or debug messages, we can do so explicitly:
 
 ```no_run
-# #[macro_use]
-# extern crate log;
+# use log::{debug, info, warn};
 # fn main() {
 debug!("this won't get through");
 // especially useful if this is from library you depend on.

--- a/src/syslog.rs
+++ b/src/syslog.rs
@@ -12,6 +12,7 @@ syslog = "4"
 To use `syslog`, simply create the log you want, and pass it into `Dispatch::chain`:
 
 ```no_run
+# use syslog4 as syslog;
 # fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
 let formatter = syslog::Formatter3164 {
     facility: syslog::Facility::LOG_USER,
@@ -70,6 +71,7 @@ However, you probably will want to format messages you also send to stdout! Fort
 configuration is easy with fern:
 
 ```no_run
+# use syslog4 as syslog;
 # fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
 let syslog_formatter = syslog::Formatter3164 {
     facility: syslog::Facility::LOG_USER,
@@ -114,6 +116,7 @@ One last pattern you might want to know: creating a log target which must be exp
 in order to work.
 
 ```no_run
+# use syslog4 as syslog;
 # fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
 # let formatter = syslog::Formatter3164 {
 #     facility: syslog::Facility::LOG_USER,

--- a/tests/channel_logging.rs
+++ b/tests/channel_logging.rs
@@ -1,8 +1,4 @@
 //! Tests!
-extern crate fern;
-extern crate log;
-extern crate tempdir;
-
 use log::Level::*;
 
 mod support;

--- a/tests/enabled_is_deep_check.rs
+++ b/tests/enabled_is_deep_check.rs
@@ -1,7 +1,5 @@
 //! See https://github.com/daboross/fern/issues/38
-extern crate fern;
-#[macro_use]
-extern crate log;
+use log::log_enabled;
 
 #[test]
 fn ensure_enabled_is_a_deep_check() {

--- a/tests/file_logging.rs
+++ b/tests/file_logging.rs
@@ -1,8 +1,4 @@
 //! Tests!
-extern crate fern;
-extern crate log;
-extern crate tempdir;
-
 use std::io::prelude::*;
 use std::{fs, io};
 

--- a/tests/global_logging.rs
+++ b/tests/global_logging.rs
@@ -45,7 +45,7 @@ impl LogVerifyWrapper {
         LogVerifyWrapper(Arc::new(Mutex::new(LogVerify::new())))
     }
 
-    fn cloned_boxed_logger(&self) -> Box<log::Log> {
+    fn cloned_boxed_logger(&self) -> Box<dyn log::Log> {
         Box::new(self.clone())
     }
 }

--- a/tests/global_logging.rs
+++ b/tests/global_logging.rs
@@ -1,8 +1,5 @@
 //! Tests!
-extern crate fern;
-#[macro_use]
-extern crate log;
-
+use log::{debug, error, info, trace, warn};
 use std::sync::{Arc, Mutex};
 
 /// Custom logger built to verify our exact test case.

--- a/tests/meta_logging.rs
+++ b/tests/meta_logging.rs
@@ -18,7 +18,7 @@ use support::manual_log;
 // in order to actually trigger the situation that deadlocks, we need a custom
 // Display implementation which performs logging:
 struct VerboseDisplayThing<'a> {
-    log_copy: &'a Log,
+    log_copy: &'a dyn Log,
     msg: &'a str,
 }
 

--- a/tests/meta_logging.rs
+++ b/tests/meta_logging.rs
@@ -4,9 +4,6 @@
 //! These tests *will* deadlock if the feature is not enabled, so they're
 //! disabled by default.
 #![cfg(feature = "meta-logging-in-format")]
-extern crate fern;
-extern crate log;
-extern crate tempdir;
 
 mod support;
 

--- a/tests/panic_logging.rs
+++ b/tests/panic_logging.rs
@@ -15,7 +15,7 @@ fn test_panic_panics() {
     manual_log(l, Info, "special panic message here");
 }
 
-fn warn_and_higher_panics_config() -> Box<log::Log> {
+fn warn_and_higher_panics_config() -> Box<dyn log::Log> {
     let (_max_level, logger) = fern::Dispatch::new()
         .chain(
             fern::Dispatch::new()

--- a/tests/panic_logging.rs
+++ b/tests/panic_logging.rs
@@ -1,7 +1,4 @@
 //! Test the functionality of panicking on error+ log messages.
-extern crate fern;
-extern crate log;
-
 use log::Level::*;
 
 mod support;

--- a/tests/reopen_logging.rs
+++ b/tests/reopen_logging.rs
@@ -1,7 +1,5 @@
 //! Tests!
-extern crate fern;
-extern crate log;
-extern crate tempdir;
+#![cfg(all(not(windows), feature = "reopen-03"))]
 
 use std::io::prelude::*;
 use std::{fs, io};
@@ -11,7 +9,6 @@ mod support;
 
 use support::manual_log;
 
-#[cfg(all(not(windows), feature = "reopen-03"))]
 #[test]
 fn test_basic_logging_reopen_logging() {
     // Create a temporary directory to put a log file into for testing
@@ -72,7 +69,6 @@ fn test_basic_logging_reopen_logging() {
         .expect("Failed to clean up temporary directory");
 }
 
-#[cfg(all(not(windows), feature = "reopen-03"))]
 #[test]
 fn test_custom_line_separators() {
     // Create a temporary directory to put a log file into for testing

--- a/tests/support.rs
+++ b/tests/support.rs
@@ -1,6 +1,4 @@
 //! Support module for tests
-extern crate log;
-
 use std::fmt;
 
 /// Utility to manually enter a log message into a logger. All extra metadata

--- a/tests/write_logging.rs
+++ b/tests/write_logging.rs
@@ -1,7 +1,4 @@
 //! Tests for the raw write logging functionality.
-extern crate fern;
-extern crate log;
-
 use std::io;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;

--- a/tests/write_logging.rs
+++ b/tests/write_logging.rs
@@ -46,7 +46,7 @@ fn test_raw_write_logging() {
         .chain(Box::new(TestWriter {
             buf: Vec::new(),
             flag: flag.clone(),
-        }) as Box<io::Write + Send>)
+        }) as Box<dyn io::Write + Send>)
         .into_log();
 
     let l = &*logger;


### PR DESCRIPTION
Mostly, this consists of [path clarity](https://doc.rust-lang.org/edition-guide/rust-2018/module-system/path-clarity.html) changes (removing `extern crate`, replacing `macro_use` with explicit macro imports) and using the [`dyn Trait` syntax for trait objects](https://doc.rust-lang.org/edition-guide/rust-2018/trait-system/dyn-trait-for-trait-objects.html). I didn't include any [anonymous lifetime](https://doc.rust-lang.org/edition-guide/rust-2018/ownership-and-lifetimes/the-anonymous-lifetime.html) edits, since I didn't see that as necessary, but we can discuss that if anyone feels differently.