### PR TITLE
Fix windows 10 coloring

### DIFF
--- a/src/colors.rs
+++ b/src/colors.rs
@@ -148,7 +148,7 @@ pub struct ColoredLevelConfig {
     pub trace: Color,
 }
 
-impl ColoredLevelConfig {
+impl ColoredLevelConfig {    
     /// Creates a new ColoredLevelConfig with the default colors.
     ///
     /// This matches the behavior of [`ColoredLevelConfig::default`].
@@ -156,6 +156,10 @@ impl ColoredLevelConfig {
     /// [`ColoredLevelConfig::default`]: #method.default
     #[inline]
     pub fn new() -> Self {
+        #[cfg(windows)]
+        {
+            let _ = colored::control::set_virtual_terminal(true);
+        }
         Self::default()
     }
 


### PR DESCRIPTION
When fern is used combined with cargo-wix to create a .msi installer coloring the output will not work anymore for Windows 10.
Windows requires a call to enable ansi escape codes which will now be called on windows platform.