### PR TITLE
Add date-based feature to gate DateBased and chrono dep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,6 @@ script:
 - cargo run --example pretty-colored --features colored
 - cargo run --example syslog --features syslog-4
 - cargo run --example syslog3 --features syslog-3
-- cargo run --example date-based-file-log
+- cargo run --example date-based-file-log --features date-based
   # we don't exactly have a good test suite for DateBased right now, so let's at least do this:
-- cargo run --example date-based-file-log --features meta-logging-in-format
+- cargo run --example date-based-file-log --features date-based,meta-logging-in-format

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ coveralls = { repository = "daboross/fern" }
 [dependencies]
 log = { version = "0.4", features = ["std"] }
 colored = { version = "1.5", optional = true }
-chrono = "0.4"
+chrono = { version = "0.4", optional = true }
 
 [target."cfg(not(windows))".dependencies]
 syslog3 = { version = "3", package = "syslog", optional = true }
@@ -37,16 +37,19 @@ syslog-3 = ["syslog3"]
 syslog-4 = ["syslog4"]
 reopen-03 = ["reopen", "libc"]
 meta-logging-in-format = []
+date-based = ["chrono"]
 
 [dev-dependencies]
 tempdir = "0.3"
 clap = "2.22"
+chrono = "0.4"
 
 [[example]]
 name = "cmd-program"
 
 [[example]]
 name = "date-based-file-log"
+required-features = ["date-based"]
 
 [[example]]
 name = "colored"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,6 +51,7 @@ test_script:
 - cargo test --verbose --features=syslog-3
 - cargo test --verbose --features=syslog-4
 - cargo test --verbose --features=meta-logging-in-format
+- cargo test --verbose --features=date-based
 - cargo test --verbose --all-features
 - cargo run --example cmd-program
 - cargo run --example cmd-program -- --verbose

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,6 +237,7 @@ pub type Formatter = dyn Fn(FormatCallback, &fmt::Arguments, &log::Record) + Syn
 /// succeed - false means it should fail.
 pub type Filter = dyn Fn(&log::Metadata) -> bool + Send + Sync + 'static;
 
+#[cfg(feature = "date-based")]
 pub use crate::builders::DateBased;
 
 #[cfg(all(not(windows), feature = "syslog-4"))]


### PR DESCRIPTION
## Motivation

I have some projects using _fern_ where I'm sensitive to new dependencies. I noticed on upgrade that _fern_ 0.5.9 promoted _chrono_ to a (non-dev) dependency. The projects in question didn't already use _chrono_, and via cargo tree one can see that _chrono_ itself has additional dependencies:

``` txt
fern v0.5.9
├── chrono v0.4.10
│   ├── num-integer v0.1.41
│   │   └── num-traits v0.2.10
│   │       [build-dependencies]
│   │       └── autocfg v0.1.7
│   │   [build-dependencies]
│   │   └── autocfg v0.1.7 (*)
│   ├── num-traits v0.2.10 (*)
│   └── time v0.1.42
│       └── libc v0.2.65
│       [dev-dependencies]
│       └── winapi v0.3.8
└── log v0.4.8
    └── cfg-if v0.1.9
```

## Solution

Add a _date-based_ feature and gate `DateBased` and the _chrono_ dependency on that feature.

Since _fern_ doesn't have any other default features, currently _date-based_ is left non-default as well.

## Alternatives

Alternatively _date-based_ could be the first default feature, which has the advantage being an entirely PATCH safe change from 0.5.9. But fern is still pre-1.x and I wonder what percentage of _fern_ users are currently using `DateBased`?

Its somewhat unclear regarding the long term future of _chrono_ vs alternative crates like _humantime_ and a more recent proposal to revive the _time_ crate with a new release: time-rs/time#190.  Thus I think a non-default _chrono_ dependency is a safer bet.
