### PR TITLE
Reopen 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,17 +27,19 @@ maintenance = { status = "passively-maintained" }
 log = { version = "0.4", features = ["std"] }
 colored = { version = "1.5", optional = true }
 chrono = { version = "0.4", optional = true }
+reopen1 = { version = "~1", package = "reopen", features = ["signals"], optional = true }
+libc = { version = "0.2.58", optional = true }
 
 [target."cfg(not(windows))".dependencies]
 syslog3 = { version = "3", package = "syslog", optional = true }
 syslog4 = { version = "4", package = "syslog", optional = true }
 reopen03 = { version = "^0.3", package = "reopen", optional = true }
-libc = { version = "0.2.58", optional = true }
 
 [features]
 syslog-3 = ["syslog3"]
 syslog-4 = ["syslog4"]
 reopen-03 = ["reopen03", "libc"]
+reopen-1 = ["reopen1", "libc"]
 meta-logging-in-format = []
 date-based = ["chrono"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,13 +31,13 @@ chrono = { version = "0.4", optional = true }
 [target."cfg(not(windows))".dependencies]
 syslog3 = { version = "3", package = "syslog", optional = true }
 syslog4 = { version = "4", package = "syslog", optional = true }
-reopen = { version = "^0.3", optional = true }
+reopen03 = { version = "^0.3", package = "reopen", optional = true }
 libc = { version = "0.2.58", optional = true }
 
 [features]
 syslog-3 = ["syslog3"]
 syslog-4 = ["syslog4"]
-reopen-03 = ["reopen", "libc"]
+reopen-03 = ["reopen03", "libc"]
 meta-logging-in-format = []
 date-based = ["chrono"]
 

--- a/src/builders.rs
+++ b/src/builders.rs
@@ -451,6 +451,14 @@ impl Dispatch {
                         line_sep,
                     }))
                 }
+                #[cfg(feature = "reopen-1")]
+                OutputInner::Reopen1 { stream, line_sep } => {
+                    max_child_level = log::LevelFilter::Trace;
+                    Some(log_impl::Output::Reopen1(log_impl::Reopen1 {
+                        stream: Mutex::new(stream),
+                        line_sep,
+                    }))
+                }
                 OutputInner::Sender { stream, line_sep } => {
                     max_child_level = log::LevelFilter::Trace;
                     Some(log_impl::Output::Sender(log_impl::Sender {
@@ -640,6 +648,13 @@ enum OutputInner {
         stream: reopen03::Reopen<fs::File>,
         line_sep: Cow<'static, str>,
     },
+    /// Writes all messages to the reopen::Reopen file with `line_sep`
+    /// separator.
+    #[cfg(feature = "reopen-1")]
+    Reopen1 {
+        stream: reopen1::Reopen<fs::File>,
+        line_sep: Cow<'static, str>,
+    },
     /// Writes all messages to mpst::Sender with `line_sep` separator.
     Sender {
         stream: Sender<String>,
@@ -784,6 +799,18 @@ impl From<reopen03::Reopen<fs::File>> for Output {
     /// in the Reopen struct, using `\n` as the separator.
     fn from(reopen: reopen03::Reopen<fs::File>) -> Self {
         Output(OutputInner::Reopen {
+            stream: reopen,
+            line_sep: "\n".into(),
+        })
+    }
+}
+
+#[cfg(feature = "reopen-1")]
+impl From<reopen1::Reopen<fs::File>> for Output {
+    /// Creates an output logger which writes all messages to the file contained
+    /// in the Reopen struct, using `\n` as the separator.
+    fn from(reopen: reopen1::Reopen<fs::File>) -> Self {
+        Output(OutputInner::Reopen1 {
             stream: reopen,
             line_sep: "\n".into(),
         })
@@ -1014,6 +1041,45 @@ impl Output {
         })
     }
 
+    /// Returns a reopenable logger, i.e., handling SIGHUP.
+    ///
+    /// If the default separator of `\n` is acceptable, a `Reopen`
+    /// instance can be passed into [`Dispatch::chain`] directly.
+    ///
+    /// This function is not available on Windows, and it requires the `reopen-03`
+    /// feature to be enabled.
+    ///
+    /// ```no_run
+    /// use std::fs::OpenOptions;
+    /// # fn setup_logger() -> Result<(), fern::InitError> {
+    /// let reopenable = reopen1::Reopen::new(Box::new(|| {
+    ///     OpenOptions::new()
+    ///         .create(true)
+    ///         .write(true)
+    ///         .append(true)
+    ///         .open("/tmp/output.log")
+    /// }))
+    /// .unwrap();
+    ///
+    /// fern::Dispatch::new().chain(fern::Output::reopen1(reopenable, "\n"))
+    ///     # .into_log();
+    /// #     Ok(())
+    /// # }
+    /// #
+    /// # fn main() { setup_logger().expect("failed to set up logger"); }
+    /// ```
+    /// [`Dispatch::chain`]: struct.Dispatch.html#method.chain
+    #[cfg(feature = "reopen-1")]
+    pub fn reopen1<T: Into<Cow<'static, str>>>(
+        reopen: reopen1::Reopen<fs::File>,
+        line_sep: T,
+    ) -> Self {
+        Output(OutputInner::Reopen1 {
+            stream: reopen,
+            line_sep: line_sep.into(),
+        })
+    }
+
     /// Returns an stdout logger using a custom separator.
     ///
     /// If the default separator of `\n` is acceptable, an `io::Stdout`
@@ -1228,6 +1294,15 @@ impl fmt::Debug for OutputInner {
             OutputInner::Reopen { ref line_sep, .. } => f
                 .debug_struct("Output::Reopen")
                 .field("stream", &"<unknown reopen file>")
+                .field("line_sep", line_sep)
+                .finish(),
+            #[cfg(feature = "reopen-1")]
+            OutputInner::Reopen1 {
+                ref line_sep,
+                ref stream,
+            } => f
+                .debug_struct("Output::Reopen1")
+                .field("stream", stream)
                 .field("line_sep", line_sep)
                 .finish(),
             OutputInner::Sender {

--- a/src/builders.rs
+++ b/src/builders.rs
@@ -637,7 +637,7 @@ enum OutputInner {
     /// separator.
     #[cfg(all(not(windows), feature = "reopen-03"))]
     Reopen {
-        stream: reopen::Reopen<fs::File>,
+        stream: reopen03::Reopen<fs::File>,
         line_sep: Cow<'static, str>,
     },
     /// Writes all messages to mpst::Sender with `line_sep` separator.
@@ -779,10 +779,10 @@ impl From<Box<dyn Write + Send>> for Output {
 }
 
 #[cfg(all(not(windows), feature = "reopen-03"))]
-impl From<reopen::Reopen<fs::File>> for Output {
+impl From<reopen03::Reopen<fs::File>> for Output {
     /// Creates an output logger which writes all messages to the file contained
     /// in the Reopen struct, using `\n` as the separator.
-    fn from(reopen: reopen::Reopen<fs::File>) -> Self {
+    fn from(reopen: reopen03::Reopen<fs::File>) -> Self {
         Output(OutputInner::Reopen {
             stream: reopen,
             line_sep: "\n".into(),
@@ -986,7 +986,7 @@ impl Output {
     /// ```no_run
     /// use std::fs::OpenOptions;
     /// # fn setup_logger() -> Result<(), fern::InitError> {
-    /// let reopenable = reopen::Reopen::new(Box::new(|| {
+    /// let reopenable = reopen03::Reopen::new(Box::new(|| {
     ///     OpenOptions::new()
     ///         .create(true)
     ///         .write(true)
@@ -1005,7 +1005,7 @@ impl Output {
     /// [`Dispatch::chain`]: struct.Dispatch.html#method.chain
     #[cfg(all(not(windows), feature = "reopen-03"))]
     pub fn reopen<T: Into<Cow<'static, str>>>(
-        reopen: reopen::Reopen<fs::File>,
+        reopen: reopen03::Reopen<fs::File>,
         line_sep: T,
     ) -> Self {
         Output(OutputInner::Reopen {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,3 +307,35 @@ pub fn log_reopen(path: &Path, signal: Option<libc::c_int>) -> io::Result<reopen
     }
     Ok(r)
 }
+
+/// Convenience method for opening a re-openable log file with common options.
+///
+/// The file opening is equivalent to:
+///
+/// ```no_run
+/// std::fs::OpenOptions::new()
+///     .write(true)
+///     .create(true)
+///     .append(true)
+///     .open("filename")
+/// # ;
+/// ```
+///
+/// See [`OpenOptions`] for more information.
+///
+/// [`OpenOptions`]: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html
+///
+/// This function requires the `reopen-1` feature to be enabled.
+#[cfg(feature = "reopen-1")]
+#[inline]
+pub fn log_reopen1<S: IntoIterator<Item = libc::c_int>>(path: &Path, signals: S)
+    -> io::Result<reopen1::Reopen<File>>
+{
+    let p = path.to_owned();
+    let r = reopen1::Reopen::new(Box::new(move || log_file(&p)))?;
+
+    for s in signals {
+        r.handle().register_signal(s)?;
+    }
+    Ok(r)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,9 +296,9 @@ pub fn log_file<P: AsRef<Path>>(path: P) -> io::Result<File> {
 /// feature to be enabled.
 #[cfg(all(not(windows), feature = "reopen-03"))]
 #[inline]
-pub fn log_reopen(path: &Path, signal: Option<libc::c_int>) -> io::Result<reopen::Reopen<File>> {
+pub fn log_reopen(path: &Path, signal: Option<libc::c_int>) -> io::Result<reopen03::Reopen<File>> {
     let p = path.to_owned();
-    let r = reopen::Reopen::new(Box::new(move || log_file(&p)))?;
+    let r = reopen03::Reopen::new(Box::new(move || log_file(&p)))?;
 
     if let Some(s) = signal {
         if let Err(e) = r.handle().register_signal(s) {

--- a/src/log_impl.rs
+++ b/src/log_impl.rs
@@ -21,6 +21,8 @@ use crate::{Filter, Formatter};
 use crate::{Syslog4Rfc3164Logger, Syslog4Rfc5424Logger};
 #[cfg(all(not(windows), feature = "reopen-03"))]
 use reopen03;
+#[cfg(feature = "reopen-1")]
+use reopen1;
 
 pub enum LevelConfiguration {
     JustDefault,
@@ -78,6 +80,8 @@ pub enum Output {
     DateBased(DateBased),
     #[cfg(all(not(windows), feature = "reopen-03"))]
     Reopen(Reopen),
+    #[cfg(feature = "reopen-1")]
+    Reopen1(Reopen1),
 }
 
 pub struct Stdout {
@@ -108,6 +112,12 @@ pub struct Writer {
 #[cfg(all(not(windows), feature = "reopen-03"))]
 pub struct Reopen {
     pub stream: Mutex<reopen03::Reopen<fs::File>>,
+    pub line_sep: Cow<'static, str>,
+}
+
+#[cfg(feature = "reopen-1")]
+pub struct Reopen1 {
+    pub stream: Mutex<reopen1::Reopen<fs::File>>,
     pub line_sep: Cow<'static, str>,
 }
 
@@ -316,6 +326,8 @@ impl Log for Output {
             Output::DateBased(ref s) => s.enabled(metadata),
             #[cfg(all(not(windows), feature = "reopen-03"))]
             Output::Reopen(ref s) => s.enabled(metadata),
+            #[cfg(feature = "reopen-1")]
+            Output::Reopen1(ref s) => s.enabled(metadata),
         }
     }
 
@@ -341,6 +353,8 @@ impl Log for Output {
             Output::DateBased(ref s) => s.log(record),
             #[cfg(all(not(windows), feature = "reopen-03"))]
             Output::Reopen(ref s) => s.log(record),
+            #[cfg(feature = "reopen-1")]
+            Output::Reopen1(ref s) => s.log(record),
         }
     }
 
@@ -366,6 +380,8 @@ impl Log for Output {
             Output::DateBased(ref s) => s.flush(),
             #[cfg(all(not(windows), feature = "reopen-03"))]
             Output::Reopen(ref s) => s.flush(),
+            #[cfg(feature = "reopen-1")]
+            Output::Reopen1(ref s) => s.flush(),
         }
     }
 }
@@ -572,6 +588,9 @@ writer_log_impl!(Writer);
 
 #[cfg(all(not(windows), feature = "reopen-03"))]
 writer_log_impl!(Reopen);
+
+#[cfg(feature = "reopen-1")]
+writer_log_impl!(Reopen1);
 
 impl Log for Sender {
     fn enabled(&self, _: &log::Metadata) -> bool {

--- a/src/log_impl.rs
+++ b/src/log_impl.rs
@@ -20,7 +20,7 @@ use crate::{Filter, Formatter};
 #[cfg(all(not(windows), feature = "syslog-4"))]
 use crate::{Syslog4Rfc3164Logger, Syslog4Rfc5424Logger};
 #[cfg(all(not(windows), feature = "reopen-03"))]
-use reopen;
+use reopen03;
 
 pub enum LevelConfiguration {
     JustDefault,
@@ -107,7 +107,7 @@ pub struct Writer {
 
 #[cfg(all(not(windows), feature = "reopen-03"))]
 pub struct Reopen {
-    pub stream: Mutex<reopen::Reopen<fs::File>>,
+    pub stream: Mutex<reopen03::Reopen<fs::File>>,
     pub line_sep: Cow<'static, str>,
 }
 

--- a/tests/reopen_logging.rs
+++ b/tests/reopen_logging.rs
@@ -1,5 +1,5 @@
 //! Tests!
-#![cfg(all(not(windows), feature = "reopen-03"))]
+#![cfg(feature = "reopen-1")]
 use std::{fs, io, io::prelude::*};
 
 use log::Level::*;
@@ -20,7 +20,7 @@ fn test_basic_logging_reopen_logging() {
             .format(|out, msg, record| out.finish(format_args!("[{}] {}", record.level(), msg)))
             .level(log::LevelFilter::Info)
             .chain(io::stdout())
-            .chain(fern::log_reopen(&log_file, None).expect("Failed to open log file"))
+            .chain(fern::log_reopen1(&log_file, None).expect("Failed to open log file"))
             .into_log();
 
         let l = &*logger;
@@ -80,8 +80,8 @@ fn test_custom_line_separators() {
             // default format is just the message if not specified
             // default log level is 'trace' if not specified (logs all messages)
             // output to the log file with the "\r\n" line separator.
-            .chain(fern::Output::reopen(
-                fern::log_reopen(&log_file, None).expect("Failed to open log file"),
+            .chain(fern::Output::reopen1(
+                fern::log_reopen1(&log_file, None).expect("Failed to open log file"),
                 "\r\n",
             ))
             .into_log();


### PR DESCRIPTION
This is for #66. Also, it is supported on windows now (though the list of usable signals is quite small and one would prefer reopening by the handle manually there probably).

But I'm not entirely happy about it, to be honest. The fact reopen-0.3 already used all the `reopen` functions and `Reopen` variants, and the stable version now has to use `reopen1` seems a bit inelegant. Any suggestions?