### PR TITLE
Bump colored crate for true color support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ maintenance = { status = "passively-maintained" }
 
 [dependencies]
 log = { version = "0.4", features = ["std"] }
-colored = { version = "1.5", optional = true }
+colored = { version = "2.0.0", optional = true }
 chrono = { version = "0.4", optional = true }
 
 [target."cfg(not(windows))".dependencies]

--- a/examples/pretty-colored.rs
+++ b/examples/pretty-colored.rs
@@ -43,7 +43,12 @@ fn set_up_logging() {
     // configure colors for the whole line
     let colors_line = ColoredLevelConfig::new()
         .error(Color::Red)
-        .warn(Color::Yellow)
+        // custom color (orange)
+        .warn(Color::TrueColor {
+            r: 255,
+            g: 165,
+            b: 0,
+        })
         // we actually don't need to specify the color for debug and info, they are white by default
         .info(Color::White)
         .debug(Color::White)


### PR DESCRIPTION
I realized that [colored](https://github.com/mackwic/colored) crate is outdated in `fern` and checked it's [changelog](https://github.com/mackwic/colored/blob/master/CHANGELOG.md) to see if there's any breaking changes. Apparently there's not an outstanding change expect the true color support which is added in the latest (`2.0.0`) release.

So this PR bumps the version of colored crate to support true colors. (115710b)
I also updated the `pretty-colored` example for demonstrating the use of true colors. (e419505)