### PR TITLE
add support for syslog 6 to fern

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ script:
 - cargo test --verbose --features=colored
 - cargo test --verbose --features=syslog-3
 - cargo test --verbose --features=syslog-4
+- cargo test --verbose --features=syslog-6
 - cargo test --verbose --features=reopen-03
 - cargo test --verbose --features=meta-logging-in-format
 - cargo test --verbose --all-features
@@ -37,7 +38,8 @@ script:
 - cargo run --example cmd-program -- --verbose
 - cargo run --example colored --features colored
 - cargo run --example pretty-colored --features colored
-- cargo run --example syslog --features syslog-4
+- cargo run --example syslog --features syslog-6
+- cargo run --example syslog4 --features syslog-4
 - cargo run --example syslog3 --features syslog-3
 - cargo run --example date-based-file-log --features date-based
   # we don't exactly have a good test suite for DateBased right now, so let's at least do this:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,12 +31,14 @@ chrono = { version = "0.4", optional = true }
 [target."cfg(not(windows))".dependencies]
 syslog3 = { version = "3", package = "syslog", optional = true }
 syslog4 = { version = "4", package = "syslog", optional = true }
+syslog6 = { version = "6", package = "syslog", optional = true }
 reopen = { version = "^0.3", optional = true }
 libc = { version = "0.2.58", optional = true }
 
 [features]
 syslog-3 = ["syslog3"]
 syslog-4 = ["syslog4"]
+syslog-6 = ["syslog6"]
 reopen-03 = ["reopen", "libc"]
 meta-logging-in-format = []
 date-based = ["chrono"]
@@ -63,6 +65,10 @@ required-features = ["colored"]
 
 [[example]]
 name = "syslog"
+required-features = ["syslog-6"]
+
+[[example]]
+name = "syslog4"
 required-features = ["syslog-4"]
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ maintenance = { status = "passively-maintained" }
 [dependencies]
 log = { version = "0.4", features = ["std"] }
 colored = { version = "1.5", optional = true }
-chrono = { version = "0.4", optional = true }
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"], optional = true }
 
 [target."cfg(not(windows))".dependencies]
 syslog3 = { version = "3", package = "syslog", optional = true }
@@ -46,7 +46,7 @@ date-based = ["chrono"]
 [dev-dependencies]
 tempdir = "0.3"
 clap = "2.22"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"]}
 
 [[example]]
 name = "cmd-program"

--- a/examples/syslog4.rs
+++ b/examples/syslog4.rs
@@ -1,6 +1,6 @@
 #[cfg(not(windows))]
 // This is necessary because `fern` depends on both version 3 and 4.
-use syslog6 as syslog;
+use syslog4 as syslog;
 
 use log::{debug, info, warn};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,6 +250,12 @@ type Syslog4Rfc5424Logger = syslog4::Logger<
     syslog4::Formatter5424,
 >;
 
+#[cfg(all(not(windows), feature = "syslog-6"))]
+type Syslog6Rfc3164Logger = syslog6::Logger<syslog6::LoggerBackend, syslog6::Formatter3164>;
+
+#[cfg(all(not(windows), feature = "syslog-6"))]
+type Syslog6Rfc5424Logger = syslog6::Logger<syslog6::LoggerBackend, syslog6::Formatter5424>;
+
 /// Convenience method for opening a log file with common options.
 ///
 /// Equivalent to:

--- a/src/syslog.rs
+++ b/src/syslog.rs
@@ -5,14 +5,14 @@ Be sure to depend on `syslog` and the `syslog` feature in `Cargo.toml`:
 
 ```toml
 [dependencies]
-fern = { version = "0.5", features = ["syslog-4"] }]
-syslog = "4"
+fern = { version = "0.5", features = ["syslog-6"] }]
+syslog = "6"
 ```
 
 To use `syslog`, simply create the log you want, and pass it into `Dispatch::chain`:
 
 ```no_run
-# use syslog4 as syslog;
+# use syslog6 as syslog;
 # fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
 let formatter = syslog::Formatter3164 {
     facility: syslog::Facility::LOG_USER,
@@ -37,8 +37,8 @@ If you're using syslog=4.0.0 exactly, one line "ok" will be printed to stdout on
 This is [a bug in syslog](https://github.com/Geal/rust-syslog/issues/39), and there is nothing we
 can change in fern to fix that.
 
-One way to avoid this is to use an earlier version of syslog, which `fern` also supports. To do
-this, depend on `syslog = 3` instead.
+One way to avoid this is to use a different version of `syslog`, `fern` also supports. To pin syslog3,
+use the `syslog-3` feature and depend on `syslog = "3"` instead.
 
 ```toml
 [dependencies]
@@ -59,8 +59,8 @@ fern::Dispatch::new()
 # fn main() { setup_logging().ok(); }
 ```
 
-The rest of this document applies to both syslog 3 and syslog 4, but the examples will be using
-syslog 4 as it is the latest version.
+The rest of this document applies to all syslog versions, but the examples will be using
+syslog 6 as it is the latest version.
 
 ---
 
@@ -71,7 +71,7 @@ However, you probably will want to format messages you also send to stdout! Fort
 configuration is easy with fern:
 
 ```no_run
-# use syslog4 as syslog;
+# use syslog6 as syslog;
 # fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
 let syslog_formatter = syslog::Formatter3164 {
     facility: syslog::Facility::LOG_USER,
@@ -116,7 +116,7 @@ One last pattern you might want to know: creating a log target which must be exp
 in order to work.
 
 ```no_run
-# use syslog4 as syslog;
+# use syslog6 as syslog;
 # fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
 # let formatter = syslog::Formatter3164 {
 #     facility: syslog::Facility::LOG_USER,


### PR DESCRIPTION
See #47

I did this in a way that keeps all syslog-3 and syslog-4 functionality intact.