### PR TITLE
Re-add fern prefix to temporary directories used for testing

### DIFF
--- a/tests/file_logging.rs
+++ b/tests/file_logging.rs
@@ -10,7 +10,7 @@ use support::manual_log;
 #[test]
 fn test_basic_logging_file_logging() {
     // Create a temporary directory to put a log file into for testing
-    let temp_log_dir = tempfile::tempdir().expect("Failed to set up temporary directory");
+    let temp_log_dir = tempfile::tempdir().prefix("fern").expect("Failed to set up temporary directory");
     let log_file = temp_log_dir.path().join("test.log");
 
     {
@@ -70,7 +70,7 @@ fn test_basic_logging_file_logging() {
 #[test]
 fn test_custom_line_separators() {
     // Create a temporary directory to put a log file into for testing
-    let temp_log_dir = tempfile::tempdir().expect("Failed to set up temporary directory");
+    let temp_log_dir = tempfile::tempdir().prefix("fern").expect("Failed to set up temporary directory");
     let log_file = temp_log_dir.path().join("test_custom_line_sep.log");
 
     {

--- a/tests/meta_logging.rs
+++ b/tests/meta_logging.rs
@@ -36,7 +36,7 @@ impl<'a> fmt::Display for VerboseDisplayThing<'a> {
 #[test]
 fn file_deadlock() {
     // Create a temporary directory to put a log file into for testing
-    let temp_log_dir = tempfile::tempdir().expect("Failed to set up temporary directory");
+    let temp_log_dir = tempfile::tempdir().prefix("fern").expect("Failed to set up temporary directory");
     let log_file = temp_log_dir.path().join("test.log");
 
     {

--- a/tests/reopen_logging.rs
+++ b/tests/reopen_logging.rs
@@ -11,7 +11,7 @@ use support::manual_log;
 #[test]
 fn test_basic_logging_reopen_logging() {
     // Create a temporary directory to put a log file into for testing
-    let temp_log_dir = tempfile::tempdir().expect("Failed to set up temporary directory");
+    let temp_log_dir = tempfile::tempdir().prefix("fern").expect("Failed to set up temporary directory");
     let log_file = temp_log_dir.path().join("test.log");
 
     {
@@ -71,7 +71,7 @@ fn test_basic_logging_reopen_logging() {
 #[test]
 fn test_custom_line_separators() {
     // Create a temporary directory to put a log file into for testing
-    let temp_log_dir = tempfile::tempdir().expect("Failed to set up temporary directory");
+    let temp_log_dir = tempfile::tempdir().prefix("fern").expect("Failed to set up temporary directory");
     let log_file = temp_log_dir.path().join("test_custom_line_sep.log");
 
     {


### PR DESCRIPTION
This is a small amendment to https://github.com/daboross/fern/pull/92.