### PR TITLE
Fix reopen-1 feature on Windows

### DIFF
--- a/0001-Fix-reopen-1-feature-on-Windows.patch
+++ b/0001-Fix-reopen-1-feature-on-Windows.patch
@@ -1,0 +1,152 @@
+From 0cd9d4773dbdcb9ba8fb6904549dc46de1c11f59 Mon Sep 17 00:00:00 2001
+From: David Ross <daboross@daboross.net>
+Date: Fri, 15 Apr 2022 06:19:14 -0700
+Subject: [PATCH] Fix reopen-1 feature on Windows
+
+---
+ src/builders.rs | 10 +++++-----
+ src/lib.rs      |  2 +-
+ src/log_impl.rs | 16 ++++++++--------
+ 3 files changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/src/builders.rs b/src/builders.rs
+index d5f1c68..071d8fc 100644
+--- a/src/builders.rs
++++ b/src/builders.rs
+@@ -454,7 +454,7 @@ impl Dispatch {
+                         line_sep,
+                     }))
+                 }
+-                #[cfg(feature = "reopen-1")]
++                #[cfg(all(not(windows), feature = "reopen-1"))]
+                 OutputInner::Reopen1 { stream, line_sep } => {
+                     max_child_level = log::LevelFilter::Trace;
+                     Some(log_impl::Output::Reopen1(log_impl::Reopen1 {
+@@ -668,7 +668,7 @@ enum OutputInner {
+     },
+     /// Writes all messages to the reopen::Reopen file with `line_sep`
+     /// separator.
+-    #[cfg(feature = "reopen-1")]
++    #[cfg(all(not(windows), feature = "reopen-1"))]
+     Reopen1 {
+         stream: reopen1::Reopen<fs::File>,
+         line_sep: Cow<'static, str>,
+@@ -835,7 +835,7 @@ impl From<reopen03::Reopen<fs::File>> for Output {
+     }
+ }
+ 
+-#[cfg(feature = "reopen-1")]
++#[cfg(all(not(windows), feature = "reopen-1"))]
+ impl From<reopen1::Reopen<fs::File>> for Output {
+     /// Creates an output logger which writes all messages to the file contained
+     /// in the Reopen struct, using `\n` as the separator.
+@@ -1118,7 +1118,7 @@ impl Output {
+     /// # fn main() { setup_logger().expect("failed to set up logger"); }
+     /// ```
+     /// [`Dispatch::chain`]: struct.Dispatch.html#method.chain
+-    #[cfg(feature = "reopen-1")]
++    #[cfg(all(not(windows), feature = "reopen-1"))]
+     pub fn reopen1<T: Into<Cow<'static, str>>>(
+         reopen: reopen1::Reopen<fs::File>,
+         line_sep: T,
+@@ -1373,7 +1373,7 @@ impl fmt::Debug for OutputInner {
+                 .field("stream", &"<unknown reopen file>")
+                 .field("line_sep", line_sep)
+                 .finish(),
+-            #[cfg(feature = "reopen-1")]
++            #[cfg(all(not(windows), feature = "reopen-1"))]
+             OutputInner::Reopen1 {
+                 ref line_sep,
+                 ref stream,
+diff --git a/src/lib.rs b/src/lib.rs
+index 2559abc..8517717 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -332,7 +332,7 @@ pub fn log_reopen(path: &Path, signal: Option<libc::c_int>) -> io::Result<reopen
+ /// [`OpenOptions`]: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html
+ ///
+ /// This function requires the `reopen-1` feature to be enabled.
+-#[cfg(feature = "reopen-1")]
++#[cfg(all(not(windows), feature = "reopen-1"))]
+ #[inline]
+ pub fn log_reopen1<S: IntoIterator<Item = libc::c_int>>(path: &Path, signals: S)
+     -> io::Result<reopen1::Reopen<File>>
+diff --git a/src/log_impl.rs b/src/log_impl.rs
+index 91d67d2..d026df4 100644
+--- a/src/log_impl.rs
++++ b/src/log_impl.rs
+@@ -23,7 +23,7 @@ use crate::{Syslog4Rfc3164Logger, Syslog4Rfc5424Logger};
+ use crate::{Syslog6Rfc3164Logger, Syslog6Rfc5424Logger};
+ #[cfg(all(not(windows), feature = "reopen-03"))]
+ use reopen03;
+-#[cfg(feature = "reopen-1")]
++#[cfg(all(not(windows), feature = "reopen-1"))]
+ use reopen1;
+ 
+ pub enum LevelConfiguration {
+@@ -86,7 +86,7 @@ pub enum Output {
+     DateBased(DateBased),
+     #[cfg(all(not(windows), feature = "reopen-03"))]
+     Reopen(Reopen),
+-    #[cfg(feature = "reopen-1")]
++    #[cfg(all(not(windows), feature = "reopen-1"))]
+     Reopen1(Reopen1),
+ }
+ 
+@@ -121,7 +121,7 @@ pub struct Reopen {
+     pub line_sep: Cow<'static, str>,
+ }
+ 
+-#[cfg(feature = "reopen-1")]
++#[cfg(all(not(windows), feature = "reopen-1"))]
+ pub struct Reopen1 {
+     pub stream: Mutex<reopen1::Reopen<fs::File>>,
+     pub line_sep: Cow<'static, str>,
+@@ -351,7 +351,7 @@ impl Log for Output {
+             Output::DateBased(ref s) => s.enabled(metadata),
+             #[cfg(all(not(windows), feature = "reopen-03"))]
+             Output::Reopen(ref s) => s.enabled(metadata),
+-            #[cfg(feature = "reopen-1")]
++            #[cfg(all(not(windows), feature = "reopen-1"))]
+             Output::Reopen1(ref s) => s.enabled(metadata),
+         }
+     }
+@@ -382,7 +382,7 @@ impl Log for Output {
+             Output::DateBased(ref s) => s.log(record),
+             #[cfg(all(not(windows), feature = "reopen-03"))]
+             Output::Reopen(ref s) => s.log(record),
+-            #[cfg(feature = "reopen-1")]
++            #[cfg(all(not(windows), feature = "reopen-1"))]
+             Output::Reopen1(ref s) => s.log(record),
+         }
+     }
+@@ -413,7 +413,7 @@ impl Log for Output {
+             Output::DateBased(ref s) => s.flush(),
+             #[cfg(all(not(windows), feature = "reopen-03"))]
+             Output::Reopen(ref s) => s.flush(),
+-            #[cfg(feature = "reopen-1")]
++            #[cfg(all(not(windows), feature = "reopen-1"))]
+             Output::Reopen1(ref s) => s.flush(),
+         }
+     }
+@@ -622,7 +622,7 @@ writer_log_impl!(Writer);
+ #[cfg(all(not(windows), feature = "reopen-03"))]
+ writer_log_impl!(Reopen);
+ 
+-#[cfg(feature = "reopen-1")]
++#[cfg(all(not(windows), feature = "reopen-1"))]
+ writer_log_impl!(Reopen1);
+ 
+ impl Log for Sender {
+@@ -644,7 +644,7 @@ impl Log for Sender {
+     fn flush(&self) {}
+ }
+ 
+-#[cfg(any(feature = "syslog-3", feature = "syslog-4", feature = "syslog-6"))]
++#[cfg(all(not(windows), any(feature = "syslog-3", feature = "syslog-4", feature = "syslog-6")))]
+ macro_rules! send_syslog {
+     ($logger:expr, $level:expr, $message:expr) => {
+         use log::Level;
+-- 
+2.35.1
+

--- a/src/builders.rs
+++ b/src/builders.rs
@@ -454,7 +454,7 @@ impl Dispatch {
                         line_sep,
                     }))
                 }
-                #[cfg(feature = "reopen-1")]
+                #[cfg(all(not(windows), feature = "reopen-1"))]
                 OutputInner::Reopen1 { stream, line_sep } => {
                     max_child_level = log::LevelFilter::Trace;
                     Some(log_impl::Output::Reopen1(log_impl::Reopen1 {
@@ -668,7 +668,7 @@ enum OutputInner {
     },
     /// Writes all messages to the reopen::Reopen file with `line_sep`
     /// separator.
-    #[cfg(feature = "reopen-1")]
+    #[cfg(all(not(windows), feature = "reopen-1"))]
     Reopen1 {
         stream: reopen1::Reopen<fs::File>,
         line_sep: Cow<'static, str>,
@@ -835,7 +835,7 @@ impl From<reopen03::Reopen<fs::File>> for Output {
     }
 }
 
-#[cfg(feature = "reopen-1")]
+#[cfg(all(not(windows), feature = "reopen-1"))]
 impl From<reopen1::Reopen<fs::File>> for Output {
     /// Creates an output logger which writes all messages to the file contained
     /// in the Reopen struct, using `\n` as the separator.
@@ -1118,7 +1118,7 @@ impl Output {
     /// # fn main() { setup_logger().expect("failed to set up logger"); }
     /// ```
     /// [`Dispatch::chain`]: struct.Dispatch.html#method.chain
-    #[cfg(feature = "reopen-1")]
+    #[cfg(all(not(windows), feature = "reopen-1"))]
     pub fn reopen1<T: Into<Cow<'static, str>>>(
         reopen: reopen1::Reopen<fs::File>,
         line_sep: T,
@@ -1373,7 +1373,7 @@ impl fmt::Debug for OutputInner {
                 .field("stream", &"<unknown reopen file>")
                 .field("line_sep", line_sep)
                 .finish(),
-            #[cfg(feature = "reopen-1")]
+            #[cfg(all(not(windows), feature = "reopen-1"))]
             OutputInner::Reopen1 {
                 ref line_sep,
                 ref stream,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,7 +332,7 @@ pub fn log_reopen(path: &Path, signal: Option<libc::c_int>) -> io::Result<reopen
 /// [`OpenOptions`]: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html
 ///
 /// This function requires the `reopen-1` feature to be enabled.
-#[cfg(feature = "reopen-1")]
+#[cfg(all(not(windows), feature = "reopen-1"))]
 #[inline]
 pub fn log_reopen1<S: IntoIterator<Item = libc::c_int>>(path: &Path, signals: S)
     -> io::Result<reopen1::Reopen<File>>

--- a/src/log_impl.rs
+++ b/src/log_impl.rs
@@ -23,7 +23,7 @@ use crate::{Syslog4Rfc3164Logger, Syslog4Rfc5424Logger};
 use crate::{Syslog6Rfc3164Logger, Syslog6Rfc5424Logger};
 #[cfg(all(not(windows), feature = "reopen-03"))]
 use reopen03;
-#[cfg(feature = "reopen-1")]
+#[cfg(all(not(windows), feature = "reopen-1"))]
 use reopen1;
 
 pub enum LevelConfiguration {
@@ -86,7 +86,7 @@ pub enum Output {
     DateBased(DateBased),
     #[cfg(all(not(windows), feature = "reopen-03"))]
     Reopen(Reopen),
-    #[cfg(feature = "reopen-1")]
+    #[cfg(all(not(windows), feature = "reopen-1"))]
     Reopen1(Reopen1),
 }
 
@@ -121,7 +121,7 @@ pub struct Reopen {
     pub line_sep: Cow<'static, str>,
 }
 
-#[cfg(feature = "reopen-1")]
+#[cfg(all(not(windows), feature = "reopen-1"))]
 pub struct Reopen1 {
     pub stream: Mutex<reopen1::Reopen<fs::File>>,
     pub line_sep: Cow<'static, str>,
@@ -351,7 +351,7 @@ impl Log for Output {
             Output::DateBased(ref s) => s.enabled(metadata),
             #[cfg(all(not(windows), feature = "reopen-03"))]
             Output::Reopen(ref s) => s.enabled(metadata),
-            #[cfg(feature = "reopen-1")]
+            #[cfg(all(not(windows), feature = "reopen-1"))]
             Output::Reopen1(ref s) => s.enabled(metadata),
         }
     }
@@ -382,7 +382,7 @@ impl Log for Output {
             Output::DateBased(ref s) => s.log(record),
             #[cfg(all(not(windows), feature = "reopen-03"))]
             Output::Reopen(ref s) => s.log(record),
-            #[cfg(feature = "reopen-1")]
+            #[cfg(all(not(windows), feature = "reopen-1"))]
             Output::Reopen1(ref s) => s.log(record),
         }
     }
@@ -413,7 +413,7 @@ impl Log for Output {
             Output::DateBased(ref s) => s.flush(),
             #[cfg(all(not(windows), feature = "reopen-03"))]
             Output::Reopen(ref s) => s.flush(),
-            #[cfg(feature = "reopen-1")]
+            #[cfg(all(not(windows), feature = "reopen-1"))]
             Output::Reopen1(ref s) => s.flush(),
         }
     }
@@ -622,7 +622,7 @@ writer_log_impl!(Writer);
 #[cfg(all(not(windows), feature = "reopen-03"))]
 writer_log_impl!(Reopen);
 
-#[cfg(feature = "reopen-1")]
+#[cfg(all(not(windows), feature = "reopen-1"))]
 writer_log_impl!(Reopen1);
 
 impl Log for Sender {
@@ -644,7 +644,7 @@ impl Log for Sender {
     fn flush(&self) {}
 }
 
-#[cfg(any(feature = "syslog-3", feature = "syslog-4", feature = "syslog-6"))]
+#[cfg(all(not(windows), any(feature = "syslog-3", feature = "syslog-4", feature = "syslog-6")))]
 macro_rules! send_syslog {
     ($logger:expr, $level:expr, $message:expr) => {
         use log::Level;

--- a/tests/reopen_logging.rs
+++ b/tests/reopen_logging.rs
@@ -1,5 +1,5 @@
 //! Tests!
-#![cfg(feature = "reopen-1")]
+#![cfg(all(not(windows), feature = "reopen-1"))]
 use std::{fs, io, io::prelude::*};
 
 use log::Level::*;


### PR DESCRIPTION
#68 included cfgs without the `not(windows)`, which causes the `reopen-1` feature to not build on Windows machines.

I want all features to build on all machines, so this PR rectifies that.