### PR TITLE
Implementation of manual rotation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,8 +80,10 @@ jobs:
       - run: cargo run --example colored --features colored
       - run: cargo run --example pretty-colored --features colored
       - run: cargo run --example date-based-file-log --features date-based
+      - run: cargo run --example manual-file-log --features manual
       # we don't exactly have a good test suite for DateBased right now, so let's at least do this:
       - run: cargo run --example date-based-file-log --features date-based,meta-logging-in-format
+      - run: cargo run --example manual-file-log --features manual,meta-logging-in-format
   linux:
     name: Linux-only Examples
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ include = ["Cargo.toml", "src/**/*", "tests/**/*", "examples/**/*", "LICENSE", "
 log = { version = "0.4", features = ["std"] }
 colored = { version = "1.5", optional = true }
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"], optional = true }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 [target."cfg(not(windows))".dependencies]
 syslog3 = { version = "3", package = "syslog", optional = true }
@@ -30,6 +31,7 @@ reopen03 = { version = "^0.3", package = "reopen", optional = true }
 libc = { version = "0.2.58", optional = true }
 
 [features]
+default = ["manual"]
 syslog-3 = ["syslog3"]
 syslog-4 = ["syslog4"]
 syslog-6 = ["syslog6"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ reopen03 = { version = "^0.3", package = "reopen", optional = true }
 libc = { version = "0.2.58", optional = true }
 
 [features]
-default = ["manual"]
 syslog-3 = ["syslog3"]
 syslog-4 = ["syslog4"]
 syslog-6 = ["syslog6"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ include = ["Cargo.toml", "src/**/*", "tests/**/*", "examples/**/*", "LICENSE", "
 log = { version = "0.4", features = ["std"] }
 colored = { version = "1.5", optional = true }
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"], optional = true }
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 [target."cfg(not(windows))".dependencies]
 syslog3 = { version = "3", package = "syslog", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ manual = ["chrono"]
 tempfile = "3"
 clap = "2.22"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"]}
+lazy_static = "1.4"
 
 [[example]]
 name = "cmd-program"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ reopen-03 = ["reopen03", "libc"]
 reopen-1 = ["reopen1", "libc"]
 meta-logging-in-format = []
 date-based = ["chrono"]
+manual = ["chrono"]
 
 [dev-dependencies]
 tempfile = "3"
@@ -49,6 +50,10 @@ name = "cmd-program"
 [[example]]
 name = "date-based-file-log"
 required-features = ["date-based"]
+
+[[example]]
+name = "manual-file-log"
+required-features = ["manual"]
 
 [[example]]
 name = "colored"

--- a/examples/manual-file-log.rs
+++ b/examples/manual-file-log.rs
@@ -1,0 +1,28 @@
+use log::{debug, info, warn};
+
+fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
+    fern::Dispatch::new()
+        .level(log::LevelFilter::Debug)
+        .chain(fern::Manual::new("program.log.", "%Y-%m-%d"))
+        .apply()?;
+
+    Ok(())
+}
+
+fn main() {
+    setup_logging().expect("failed to initialize logging.");
+
+    for i in 0..5 {
+        info!("executing section: {}", i);
+
+        debug!("section {} 1/4 complete.", i);
+
+        debug!("section {} 1/2 complete.", i);
+
+        debug!("section {} 3/4 complete.", i);
+
+        info!("section {} completed!", i);
+    }
+
+    warn!("AHHH something's on fire.");
+}

--- a/src/builders.rs
+++ b/src/builders.rs
@@ -407,7 +407,7 @@ impl Dispatch {
     ///
     /// This could probably be refactored, but having everything in one place
     /// is also nice.
-    fn into_dispatch(self) -> (log::LevelFilter, log_impl::Dispatch) {
+    pub fn into_dispatch(self) -> (log::LevelFilter, log_impl::Dispatch) {
         let Dispatch {
             format,
             children,
@@ -586,7 +586,8 @@ impl Dispatch {
                     // ignore errors - we'll just retry later.
                     let initial_file = manual_config.open_current_log_file(&computed_suffix).ok();
 
-                    let state = Arc::new(Mutex::new(ManualState::new(computed_suffix, initial_file)));
+                    let state =
+                        Arc::new(Mutex::new(ManualState::new(computed_suffix, initial_file)));
                     config.state(state.clone());
 
                     Some(log_impl::Output::Manual(log_impl::Manual {
@@ -1089,8 +1090,8 @@ impl Output {
     /// If the default separator of `\n` is acceptable, a `Reopen`
     /// instance can be passed into [`Dispatch::chain`] directly.
     ///
-    /// This function is not available on Windows, and it requires the `reopen-03`
-    /// feature to be enabled.
+    /// This function is not available on Windows, and it requires the
+    /// `reopen-03` feature to be enabled.
     ///
     /// ```no_run
     /// use std::fs::OpenOptions;
@@ -1128,8 +1129,8 @@ impl Output {
     /// If the default separator of `\n` is acceptable, a `Reopen`
     /// instance can be passed into [`Dispatch::chain`] directly.
     ///
-    /// This function is not available on Windows, and it requires the `reopen-03`
-    /// feature to be enabled.
+    /// This function is not available on Windows, and it requires the
+    /// `reopen-03` feature to be enabled.
     ///
     /// ```no_run
     /// use std::fs::OpenOptions;
@@ -1262,7 +1263,8 @@ impl Output {
         })
     }
 
-    /// Returns a logger which logs into an RFC5424 syslog (using syslog version 6)
+    /// Returns a logger which logs into an RFC5424 syslog (using syslog version
+    /// 6)
     ///
     /// This method takes an additional transform method to turn the log data
     /// into RFC5424 data.
@@ -1837,7 +1839,7 @@ impl Manual {
                                 Ok(file) => {
                                     state.replace_file(new_suffix, Some(file));
                                 }
-                                Err(e) => {
+                                Err(_e) => {
                                     state.replace_file(new_suffix, None);
                                 }
                             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,6 +216,9 @@ pub use crate::{
     log_impl::FormatCallback,
 };
 
+#[cfg(feature = "manual")]
+pub use crate::log_impl::Dispatch as ImplDispatch;
+
 mod builders;
 mod errors;
 mod log_impl;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,6 +240,9 @@ pub type Filter = dyn Fn(&log::Metadata) -> bool + Send + Sync + 'static;
 #[cfg(feature = "date-based")]
 pub use crate::builders::DateBased;
 
+#[cfg(feature = "manual")]
+pub use crate::builders::Manual;
+
 #[cfg(all(not(windows), feature = "syslog-4"))]
 type Syslog4Rfc3164Logger = syslog4::Logger<syslog4::LoggerBackend, String, syslog4::Formatter3164>;
 

--- a/src/log_impl.rs
+++ b/src/log_impl.rs
@@ -582,9 +582,18 @@ impl Dispatch {
             && self.filters.iter().all(|f| f(metadata))
     }
 
+    /// Check whether a log with the given metadata would eventually end up
+    /// outputting something.
+    ///
+    /// This is recursive, and checks children.
+    fn deep_enabled(&self, metadata: &log::Metadata) -> bool {
+        self.shallow_enabled(metadata) && self.output.iter().any(|l| l.enabled(metadata))
+    }
+
     /// Rotate the log target, if given.
     ///
     /// Returns `Some((old_path, new_path))` if rotated, `None` otherwise.
+    #[cfg(feature = "manual")]
     pub fn rotate(&self) -> Vec<Option<(PathBuf, PathBuf)>> {
         self.output
             .iter()
@@ -596,14 +605,6 @@ impl Dispatch {
                 }
             })
             .collect()
-    }
-
-    /// Check whether a log with the given metadata would eventually end up
-    /// outputting something.
-    ///
-    /// This is recursive, and checks children.
-    fn deep_enabled(&self, metadata: &log::Metadata) -> bool {
-        self.shallow_enabled(metadata) && self.output.iter().any(|l| l.enabled(metadata))
     }
 }
 

--- a/src/log_impl.rs
+++ b/src/log_impl.rs
@@ -32,6 +32,7 @@ pub enum LevelConfiguration {
     Many(HashMap<Cow<'static, str>, log::LevelFilter>),
 }
 
+#[allow(missing_docs)]
 pub struct Dispatch {
     pub output: Vec<Output>,
     pub default_level: log::LevelFilter,

--- a/src/log_impl.rs
+++ b/src/log_impl.rs
@@ -181,10 +181,10 @@ pub struct DateBased {
 #[cfg(feature = "manual")]
 pub struct Manual {
     pub config: ManualConfig,
-    pub state: Mutex<ManualState>,
+    pub state: Arc<Mutex<ManualState>>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg(any(feature = "date-based", feature = "manual"))]
 pub enum ConfiguredTimezone {
     Local,
@@ -201,7 +201,7 @@ pub struct DateBasedConfig {
     pub timezone: ConfiguredTimezone,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg(feature = "manual")]
 pub struct ManualConfig {
     pub line_sep: Cow<'static, str>,
@@ -925,20 +925,20 @@ impl Log for Manual {
 
             let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
 
-            // check if log needs to be rotated
-            let new_suffix = self.config.compute_current_suffix();
-            if state.file_stream.is_none() || state.current_suffix != new_suffix {
-                let file_open_result = self.config.open_current_log_file(&new_suffix);
-                match file_open_result {
-                    Ok(file) => {
-                        state.replace_file(new_suffix, Some(file));
-                    }
-                    Err(e) => {
-                        state.replace_file(new_suffix, None);
-                        return Err(e.into());
-                    }
-                }
-            }
+            // // check if log needs to be rotated
+            // let new_suffix = self.config.compute_current_suffix();
+            // if state.file_stream.is_none() || state.current_suffix != new_suffix {
+            //     let file_open_result = self.config.open_current_log_file(&new_suffix);
+            //     match file_open_result {
+            //         Ok(file) => {
+            //             state.replace_file(new_suffix, Some(file));
+            //         }
+            //         Err(e) => {
+            //             state.replace_file(new_suffix, None);
+            //             return Err(e.into());
+            //         }
+            //     }
+            // }
 
             // either just initialized writer above, or already errored out.
             let writer = state.file_stream.as_mut().unwrap();

--- a/tests/manual_rotating.rs
+++ b/tests/manual_rotating.rs
@@ -14,18 +14,31 @@ use support::manual_log;
 #[test]
 fn test_basic_logging_manual_rotating() {
     // Create a basic logger configuration
+    let builder = fern::Manual::new("program.log.", "%Y-%m-%d_%H-%M-%S%.f");
     let (_max_level, logger) = fern::Dispatch::new()
         .format(|out, msg, record| out.finish(format_args!("[{}] {}", record.level(), msg)))
         .level(log::LevelFilter::Info)
-        .chain(fern::Manual::new("program.log.", "%Y-%m-%d"))
+        .chain(builder.clone())
         .into_log();
 
     let l = &*logger;
-    manual_log(l, Trace, "SHOULD NOT DISPLAY");
-    manual_log(l, Debug, "SHOULD NOT DISPLAY");
-    manual_log(l, Info, "Test information message");
-    manual_log(l, Warn, "Test warning message");
-    manual_log(l, Error, "Test error message");
+    for x in 1..10000 {
+        manual_log(l, Trace, "SHOULD NOT DISPLAY");
+        manual_log(l, Debug, "SHOULD NOT DISPLAY");
+        manual_log(l, Info, "Test information message");
+        manual_log(l, Warn, "Test warning message");
+        manual_log(l, Error, "Test error message");
+    }
+
+    builder.rotate();
+
+    for x in 1..10000 {
+        manual_log(l, Trace, "SHOULD NOT DISPLAY");
+        manual_log(l, Debug, "SHOULD NOT DISPLAY");
+        manual_log(l, Info, "Test information message");
+        manual_log(l, Warn, "Test warning message");
+        manual_log(l, Error, "Test error message");
+    }
 
     // ensure all File objects are dropped and OS buffers are flushed.
     log::logger().flush();

--- a/tests/manual_rotating.rs
+++ b/tests/manual_rotating.rs
@@ -15,29 +15,28 @@ use support::manual_log;
 fn test_basic_logging_manual_rotating() {
     // Create a basic logger configuration
     let builder = fern::Manual::new("program.log.", "%Y-%m-%d_%H-%M-%S%.f");
-    let (_max_level, logger) = fern::Dispatch::new()
+    let (_level, l) = fern::Dispatch::new()
         .format(|out, msg, record| out.finish(format_args!("[{}] {}", record.level(), msg)))
         .level(log::LevelFilter::Info)
         .chain(builder.clone())
-        .into_log();
+        .into_dispatch();
 
-    let l = &*logger;
     for x in 1..10000 {
-        manual_log(l, Trace, "SHOULD NOT DISPLAY");
-        manual_log(l, Debug, "SHOULD NOT DISPLAY");
-        manual_log(l, Info, "Test information message");
-        manual_log(l, Warn, "Test warning message");
-        manual_log(l, Error, "Test error message");
+        manual_log(&l, Trace, "SHOULD NOT DISPLAY");
+        manual_log(&l, Debug, "SHOULD NOT DISPLAY");
+        manual_log(&l, Info, "Test information message");
+        manual_log(&l, Warn, "Test warning message");
+        manual_log(&l, Error, "Test error message");
     }
 
-    builder.rotate();
+    l.rotate();
 
     for x in 1..10000 {
-        manual_log(l, Trace, "SHOULD NOT DISPLAY");
-        manual_log(l, Debug, "SHOULD NOT DISPLAY");
-        manual_log(l, Info, "Test information message");
-        manual_log(l, Warn, "Test warning message");
-        manual_log(l, Error, "Test error message");
+        manual_log(&l, Trace, "SHOULD NOT DISPLAY");
+        manual_log(&l, Debug, "SHOULD NOT DISPLAY");
+        manual_log(&l, Info, "Test information message");
+        manual_log(&l, Warn, "Test warning message");
+        manual_log(&l, Error, "Test error message");
     }
 
     // ensure all File objects are dropped and OS buffers are flushed.

--- a/tests/manual_rotating.rs
+++ b/tests/manual_rotating.rs
@@ -1,0 +1,32 @@
+//! Tests!
+#[cfg(feature = "manual")]
+use std::{fs, io::prelude::*};
+
+#[cfg(feature = "manual")]
+use log::Level::*;
+
+mod support;
+
+#[cfg(feature = "manual")]
+use support::manual_log;
+
+#[cfg(feature = "manual")]
+#[test]
+fn test_basic_logging_manual_rotating() {
+    // Create a basic logger configuration
+    let (_max_level, logger) = fern::Dispatch::new()
+        .format(|out, msg, record| out.finish(format_args!("[{}] {}", record.level(), msg)))
+        .level(log::LevelFilter::Info)
+        .chain(fern::Manual::new("program.log.", "%Y-%m-%d"))
+        .into_log();
+
+    let l = &*logger;
+    manual_log(l, Trace, "SHOULD NOT DISPLAY");
+    manual_log(l, Debug, "SHOULD NOT DISPLAY");
+    manual_log(l, Info, "Test information message");
+    manual_log(l, Warn, "Test warning message");
+    manual_log(l, Error, "Test error message");
+
+    // ensure all File objects are dropped and OS buffers are flushed.
+    log::logger().flush();
+}

--- a/tests/manual_rotating.rs
+++ b/tests/manual_rotating.rs
@@ -1,44 +1,62 @@
 //! Tests!
 #[cfg(feature = "manual")]
-use std::{fs, io::prelude::*};
-
-#[cfg(feature = "manual")]
-use log::Level::*;
+use std::fs;
 
 mod support;
-
-#[cfg(feature = "manual")]
-use support::manual_log;
 
 #[cfg(feature = "manual")]
 #[test]
 fn test_basic_logging_manual_rotating() {
     // Create a basic logger configuration
-    let builder = fern::Manual::new("program.log.", "%Y-%m-%d_%H-%M-%S%.f");
-    let (_level, l) = fern::Dispatch::new()
+    let (level, dispatch) = fern::Dispatch::new()
         .format(|out, msg, record| out.finish(format_args!("[{}] {}", record.level(), msg)))
         .level(log::LevelFilter::Info)
-        .chain(builder.clone())
-        .into_dispatch();
+        .chain(fern::Manual::new("program.log.", "%Y-%m-%d_%H-%M-%S%.f"))
+        .into_dispatch_with_arc();
 
-    for x in 1..10000 {
-        manual_log(&l, Trace, "SHOULD NOT DISPLAY");
-        manual_log(&l, Debug, "SHOULD NOT DISPLAY");
-        manual_log(&l, Info, "Test information message");
-        manual_log(&l, Warn, "Test warning message");
-        manual_log(&l, Error, "Test error message");
+    if level == log::LevelFilter::Off {
+        log::set_boxed_logger(Box::new(NullLogger)).unwrap();
+    } else {
+        log::set_boxed_logger(Box::new(dispatch.clone())).unwrap();
     }
+    log::set_max_level(level);
 
-    l.rotate();
+    log::trace!("SHOULD NOT DISPLAY");
+    log::debug!("SHOULD NOT DISPLAY");
+    log::info!("Test information message");
+    log::warn!("Test warning message");
+    log::error!("Test error message");
 
-    for x in 1..10000 {
-        manual_log(&l, Trace, "SHOULD NOT DISPLAY");
-        manual_log(&l, Debug, "SHOULD NOT DISPLAY");
-        manual_log(&l, Info, "Test information message");
-        manual_log(&l, Warn, "Test warning message");
-        manual_log(&l, Error, "Test error message");
+    let res = dispatch.rotate();
+
+    log::trace!("SHOULD NOT DISPLAY");
+    log::debug!("SHOULD NOT DISPLAY");
+    log::info!("Test information message");
+    log::warn!("Test warning message");
+    log::error!("Test error message");
+
+    for output in res.iter() {
+        match output {
+            Some((old_path, new_path)) => {
+                log::info!("old path: {}", fs::canonicalize(old_path).unwrap().to_string_lossy());
+                log::info!("new path: {}", fs::canonicalize(new_path).unwrap().to_string_lossy());
+            }
+            None => {}
+        }
     }
 
     // ensure all File objects are dropped and OS buffers are flushed.
     log::logger().flush();
+}
+
+struct NullLogger;
+
+impl log::Log for NullLogger {
+    fn enabled(&self, _: &log::Metadata) -> bool {
+        false
+    }
+
+    fn log(&self, _: &log::Record) {}
+
+    fn flush(&self) {}
 }


### PR DESCRIPTION
`fern` already implemented `date-based` auto-rotation.
But sometimes we may need manual-rotation.
For example, suppose someone found a bug and he wants to report it.
If new file generated whenever `Y-m-d_H-M-S` changes, the too many files may need to be processed for submitting to log server.
He must rotate log file to close current log file from writing and access it for submitting to server.
This is manual rotation and it can reduce the count of log files.