### PR TITLE
Revamp examples to use env_logger-style formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ date-based = ["chrono"]
 [dev-dependencies]
 tempfile = "3"
 clap = "2.22"
-chrono = { version = "0.4", default-features = false, features = ["std", "clock"]}
+humantime = "2.1.0"
 
 [[example]]
 name = "cmd-program"

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ fern::Dispatch::new()
     // Perform allocation-free log formatting
     .format(|out, message, record| {
         out.finish(format_args!(
-            "{}[{}][{}] {}",
-            chrono::Local::now().format("[%Y-%m-%d][%H:%M:%S]"),
-            record.target(),
+            "[{} {} {}] {}",
+            humantime::format_rfc3339(std::time::SystemTime::now()),
             record.level(),
+            record.target(),
             message
         ))
     })

--- a/examples/cmd-program.rs
+++ b/examples/cmd-program.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::{io, time::SystemTime};
 
 use log::{debug, info, trace, warn};
 
@@ -25,10 +25,10 @@ fn setup_logging(verbosity: u64) -> Result<(), fern::InitError> {
     let file_config = fern::Dispatch::new()
         .format(|out, message, record| {
             out.finish(format_args!(
-                "{}[{}][{}] {}",
-                chrono::Local::now().format("[%Y-%m-%d][%H:%M:%S]"),
-                record.target(),
+                "[{} {} {}] {}",
+                humantime::format_rfc3339_seconds(SystemTime::now()),
                 record.level(),
+                record.target(),
                 message
             ))
         })
@@ -39,16 +39,16 @@ fn setup_logging(verbosity: u64) -> Result<(), fern::InitError> {
             // special format for debug messages coming from our own crate.
             if record.level() > log::LevelFilter::Info && record.target() == "cmd_program" {
                 out.finish(format_args!(
-                    "---\nDEBUG: {}: {}\n---",
-                    chrono::Local::now().format("%H:%M:%S"),
+                    "DEBUG @ {}: {}",
+                    humantime::format_rfc3339_seconds(SystemTime::now()),
                     message
                 ))
             } else {
                 out.finish(format_args!(
-                    "[{}][{}][{}] {}",
-                    chrono::Local::now().format("%H:%M"),
-                    record.target(),
+                    "[{} {} {}] {}",
+                    humantime::format_rfc3339_seconds(SystemTime::now()),
                     record.level(),
+                    record.target(),
                     message
                 ))
             }

--- a/examples/colored.rs
+++ b/examples/colored.rs
@@ -1,3 +1,5 @@
+use std::time::SystemTime;
+
 use fern::colors::{Color, ColoredLevelConfig};
 use log::{debug, error, warn};
 
@@ -8,10 +10,11 @@ fn main() {
         .chain(std::io::stdout())
         .format(move |out, message, record| {
             out.finish(format_args!(
-                "[{}]{} {}",
+                "[{} {} {}] {}",
+                humantime::format_rfc3339_seconds(SystemTime::now()),
                 // This will color the log level only, not the whole line. Just a touch.
                 colors.color(record.level()),
-                chrono::Utc::now().format("[%Y-%m-%d %H:%M:%S]"),
+                record.target(),
                 message
             ))
         })

--- a/examples/pretty-colored.rs
+++ b/examples/pretty-colored.rs
@@ -6,6 +6,8 @@
 //!   line is white
 //! - when the log level is debug, the whole line is white
 //! - when the log level is trace, the whole line is gray ("bright black")
+use std::time::SystemTime;
+
 use fern::colors::{Color, ColoredLevelConfig};
 use log::{debug, error, info, trace, warn};
 
@@ -58,12 +60,12 @@ fn set_up_logging() {
     fern::Dispatch::new()
         .format(move |out, message, record| {
             out.finish(format_args!(
-                "{color_line}[{date}][{target}][{level}{color_line}] {message}\x1B[0m",
+                "{color_line}[{date} {level} {target} {color_line}] {message}\x1B[0m",
                 color_line = format_args!(
                     "\x1B[{}m",
                     colors_line.get_color(&record.level()).to_fg_str()
                 ),
-                date = chrono::Local::now().format("%Y-%m-%d %H:%M:%S"),
+                date = humantime::format_rfc3339_seconds(SystemTime::now()),
                 target = record.target(),
                 level = colors_level.color(record.level()),
                 message = message,

--- a/src/builders.rs
+++ b/src/builders.rs
@@ -45,7 +45,7 @@ use crate::{Syslog6Rfc3164Logger, Syslog6Rfc5424Logger};
 /// fern::Dispatch::new()
 ///     .format(|out, message, record| {
 ///         out.finish(format_args!(
-///             "[{}][{}] {}",
+///             "[{} {}] {}",
 ///             record.level(),
 ///             record.target(),
 ///             message,
@@ -159,7 +159,7 @@ impl Dispatch {
     /// ```
     /// fern::Dispatch::new().format(|out, message, record| {
     ///     out.finish(format_args!(
-    ///         "[{}][{}] {}",
+    ///         "[{} {}] {}",
     ///         record.level(),
     ///         record.target(),
     ///         message

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,15 +22,16 @@
 //!
 //! ```no_run
 //! use log::{debug, error, info, trace, warn};
+//! use std::time::SystemTime;
 //!
 //! fn setup_logger() -> Result<(), fern::InitError> {
 //!     fern::Dispatch::new()
 //!         .format(|out, message, record| {
 //!             out.finish(format_args!(
-//!                 "{}[{}][{}] {}",
-//!                 chrono::Local::now().format("[%Y-%m-%d][%H:%M:%S]"),
-//!                 record.target(),
+//!                 "[{} {} {}] {}",
+//!                 humantime::format_rfc3339_seconds(SystemTime::now()),
 //!                 record.level(),
+//!                 record.target(),
 //!                 message
 //!             ))
 //!         })
@@ -40,9 +41,16 @@
 //!         .apply()?;
 //!     Ok(())
 //! }
-//! # fn main() {
-//! #     setup_logger().expect("failed to set up logger")
-//! # }
+//!
+//! fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     setup_logger()?;
+//!
+//!     info!("Hello, world!");
+//!     warn!("Warning!");
+//!     debug!("Now exiting.");
+//!
+//!     Ok(())
+//! }
 //! ```
 //!
 //! Let's unwrap this:
@@ -61,16 +69,24 @@
 //!
 //! ___
 //!
-//! [`chrono::Local::now()`]
+//! [`std::time::SystemTime::now()`][std::time::SystemTime::now]
 //!
-//! Get the current time in the local timezone using the [`chrono`] library.
-//! See the [time-and-date docs].
+//! Retrieves the current time.
 //!
 //! ___
 //!
-//! [`.format("[%Y-%m-%d][%H:%M:%S]")`][chrono-format]
+//! [`humantime::format_rfc3339_seconds(...)`]
 //!
-//! Use chrono's lazy format specifier to turn the time into a readable string.
+//! Uses [`humantime`] to format this timestamp to an RFC3339 timestamp, with no
+//! fractional seconds.
+//!
+//! RFC3339 formats timestamps with `2018-02-14T00:28:07Z`, always using UTC,
+//! ignoring system timezone.
+//!
+//! `humantime` is a nice light dependency for using this format in particular.
+//! To do more custom time formatting, I recommend
+//! [chrono](https://docs.rs/chrono/) or
+//! [`time`](https://docs.rs/time/).
 //!
 //! ---
 //!
@@ -78,8 +94,8 @@
 //!
 //! Call the `fern::FormattingCallback` to submit the formatted message.
 //!
-//! This roundabout way is slightly odd, but it allows for very fast logging.
-//! No string allocation required!
+//! This roundabout way is slightly odd, but it allows for logging with no
+//! string allocation!
 //!
 //! [`format_args!()`] has the same format as [`println!()`] \(and every other
 //! [`std::fmt`]-based macro).
@@ -127,9 +143,9 @@
 //! The final output will look like:
 //!
 //! ```text
-//! [2017-01-20][12:55:04][crate-name][INFO] Hello, world!
-//! [2017-01-20][12:56:21][crate-name][WARN] Ahhh!
-//! [2017-01-20][12:58:00][crate-name][DEBUG] Something less important happened.
+//! [2023-03-18T20:12:50Z INFO cmd_program] Hello, world!
+//! [2023-03-18T20:12:50Z WARN cmd_program] Warning!
+//! [2023-03-18T20:12:50Z DEBUG cmd_program] Now exiting.
 //! ```
 //!
 //! # Logging
@@ -173,8 +189,6 @@
 //!
 //! [`fern::Dispatch::new()`]: struct.Dispatch.html#method.new
 //! [`.format(|...| ...)`]: struct.Dispatch.html#method.format
-//! [`chrono::Local::now()`]: https://docs.rs/chrono/0.4/chrono/offset/local/struct.Local.html#method.now
-//! [chrono-format]: https://docs.rs/chrono/0.4/chrono/datetime/struct.DateTime.html#method.format
 //! [`out.finish(format_args!(...))`]: struct.FormatCallback.html#method.finish
 //! [`.level(log::LevelFilter::Debug)`]: struct.Dispatch.html#method.level
 //! [`Dispatch::chain`]: struct.Dispatch.html#method.chain
@@ -190,8 +204,6 @@
 //! [`println!()`]: https://doc.rust-lang.org/std/macro.println.html
 //! [`std::fmt`]: https://doc.rust-lang.org/std/fmt/
 //! [`chrono`]: https://github.com/chronotope/chrono
-//! [time-and-date docs]: https://docs.rs/chrono/0.4/chrono/index.html#date-and-time
-//! [the format specifier docs]: https://docs.rs/chrono/0.4/chrono/format/strftime/index.html#specifiers
 //! [`Dispatch` documentation]: struct.Dispatch.html
 //! [full example program]: https://github.com/daboross/fern/tree/fern-0.6.1/examples/cmd-program.rs
 //! [syslog full example program]: https://github.com/daboross/fern/tree/fern-0.6.1/examples/syslog.rs


### PR DESCRIPTION
I think at this point it's pretty clear env_logger is the standard for Rust CLI programs. It's been this way for a while, but better late than never adapt.

The original output style in fern's examples was based on, I believe, loosely based on what Minecraft servers output at the time. Regardless, it's more useful IMO to have a consistent log style than any particular one, and env_logger's style is convenient in this way!

Side note: I'm not 100% sure the origin of this style, either. I've seen in particular some go programs outputting very similar looking log lines, and I wonder if it's more widespread, or has a particular name. I haven't been able to find one.