### PR TITLE
Revamp main doc example

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,6 +82,7 @@ jobs:
       - run: cargo run --example date-based-file-log --features date-based
       # we don't exactly have a good test suite for DateBased right now, so let's at least do this:
       - run: cargo run --example date-based-file-log --features date-based,meta-logging-in-format
+      - run: RUSTDOCFLAGS="-D warnings" cargo doc --all-features
   linux:
     name: Linux-only Examples
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,7 +82,9 @@ jobs:
       - run: cargo run --example date-based-file-log --features date-based
       # we don't exactly have a good test suite for DateBased right now, so let's at least do this:
       - run: cargo run --example date-based-file-log --features date-based,meta-logging-in-format
-      - run: RUSTDOCFLAGS="-D warnings" cargo doc --all-features
+      - run: cargo doc --all-features
+        env:
+          RUSTDOCFLAGS: -D warnings
   linux:
     name: Linux-only Examples
     runs-on: ubuntu-latest

--- a/src/builders.rs
+++ b/src/builders.rs
@@ -904,8 +904,8 @@ impl From<Box<syslog3::Logger>> for Output {
     /// Log levels are translated trace => debug, debug => debug, info =>
     /// informational, warn => warning, and error => error.
     ///
-    /// Note that while this takes a Box<Logger> for convenience (syslog
-    /// methods return Boxes), it will be immediately unboxed upon storage
+    /// Note that while this takes a `Box<Logger>` for convenience (syslog
+    /// methods return `Box`es), it will be immediately unboxed upon storage
     /// in the configuration structure. This will create a configuration
     /// identical to that created by passing a raw `syslog::Logger`.
     ///
@@ -922,7 +922,7 @@ impl From<Syslog4Rfc3164Logger> for Output {
     /// Log levels are translated trace => debug, debug => debug, info =>
     /// informational, warn => warning, and error => error.
     ///
-    /// Note that due to https://github.com/Geal/rust-syslog/issues/41,
+    /// Note that due to <https://github.com/Geal/rust-syslog/issues/41>,
     /// logging to this backend requires one allocation per log call.
     ///
     /// This is for RFC 3164 loggers. To use an RFC 5424 logger, use the
@@ -941,7 +941,7 @@ impl From<Syslog6Rfc3164Logger> for Output {
     /// Log levels are translated trace => debug, debug => debug, info =>
     /// informational, warn => warning, and error => error.
     ///
-    /// Note that due to https://github.com/Geal/rust-syslog/issues/41,
+    /// Note that due to <https://github.com/Geal/rust-syslog/issues/41>,
     /// logging to this backend requires one allocation per log call.
     ///
     /// This is for RFC 3164 loggers. To use an RFC 5424 logger, use the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@
 //!
 //! ___
 //!
-//! [`humantime::format_rfc3339_seconds(...)`]
+//! [`humantime::format_rfc3339_seconds(...)`][format_rfc3339_seconds]
 //!
 //! Uses [`humantime`] to format this timestamp to an RFC3339 timestamp, with no
 //! fractional seconds.
@@ -247,6 +247,8 @@
 //! [colors]: colors/index.html
 //! [syslog]: syslog/index.html
 //! [meta]: meta/index.html
+//! [format_rfc3339_seconds]: https://docs.rs/humantime/2/humantime/fn.format_rfc3339_seconds.html
+//! [`humantime`]: https://docs.rs/humantime/2/
 use std::{
     convert::AsRef,
     fmt,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,7 +275,14 @@ mod log_impl;
 
 #[cfg(feature = "colored")]
 pub mod colors;
-#[cfg(all(not(windows), feature = "syslog-3", feature = "syslog-4"))]
+#[cfg(all(
+    feature = "syslog-3",
+    feature = "syslog-4",
+    // disable on windows when running doctests, as the code itself only runs on
+    // linux. enable on windows otherwise because it's a documentation-only
+    // module.
+    any(not(windows), not(doctest))
+))]
 pub mod syslog;
 
 pub mod meta;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,60 +91,88 @@
 //!
 //! Let's unwrap this:
 //!
-//! ---
 //!
-//! [`fern::Dispatch::new()`]
+//! ```
+//! fern::Dispatch::new()
+//! # ;
+//! ```
 //!
-//! Create an empty configuration.
+//! [`Dispatch::new`] creates an empty configuration.
 //!
-//! ---
+//! ```
+//! # fern::Dispatch::new()
+//! .format(|out, message, record| {
+//!     // ...
+//! })
+//! # ;
+//! ```
 //!
-//! [`.format(|...| ...)`]
+//! [`Dispatch::format`] sets the formatter of the dispatch, modifying all
+//! messages sent through.
 //!
-//! Add a formatter to the logger, modifying all messages sent through.
+//! ```
+//! std::time::SystemTime::now()
+//! # ;
+//! ```
 //!
-//! ___
+//! [`std::time::SystemTime::now`] retrieves the current time.
 //!
-//! [`std::time::SystemTime::now()`][std::time::SystemTime::now]
+//! ```
+//! humantime::format_rfc3339_seconds(
+//!     // ...
+//!     # std::time::SystemTime::now()
+//! )
+//! # ;
+//! ```
 //!
-//! Retrieves the current time.
+//! [`humantime::format_rfc3339_seconds`] formats the current time into an
+//! RFC3339 timestamp, with second-precision.
 //!
-//! ___
+//! RFC3339 looks like `2018-02-14T00:28:07Z`, always using UTC, ignoring system
+//! timezone.
 //!
-//! [`humantime::format_rfc3339_seconds(...)`][format_rfc3339_seconds]
-//!
-//! Uses [`humantime`] to format this timestamp to an RFC3339 timestamp, with no
-//! fractional seconds.
-//!
-//! RFC3339 formats timestamps with `2018-02-14T00:28:07Z`, always using UTC,
-//! ignoring system timezone.
-//!
-//! `humantime` is a nice light dependency for using this format in particular.
+//! `humantime` is a nice light dependency, but does only offer this one format.
 //! To do more custom time formatting, I recommend
-//! [chrono](https://docs.rs/chrono/) or
+//! [`chrono`](https://docs.rs/chrono/) or
 //! [`time`](https://docs.rs/time/).
 //!
-//! ---
 //!
-//! [`out.finish(format_args!(...))`]
+//! ```
+//! # fern::Dispatch::new().format(|out, message, record| {
+//! out.finish(format_args!(
+//!     # /*
+//!     ...
+//!     # */ ""
+//! ))
+//! # });
+//! ```
 //!
 //! Call the `fern::FormattingCallback` to submit the formatted message.
 //!
-//! This roundabout way is slightly odd, but it allows for logging with no
-//! string allocation!
+//! This callback-style allows for logging with no intermediate string
+//! allocation!
 //!
-//! [`format_args!()`] has the same format as [`println!()`] \(and every other
-//! [`std::fmt`]-based macro).
+//! [`format_args!`] has the same format as [`println!`], just returning a
+//! not-yet-written result we can use internally.
 //!
-//! ---
+//! Now, back to the [`Dispatch`] methods:
 //!
-//! [`.level(log::LevelFilter::Debug)`]
 //!
-//! Set the minimum level needed to output to `Debug`.
+//! ```
+//! # fern::Dispatch::new()
+//! .level(log::LevelFilter::Debug)
+//! # ;
+//! ```
 //!
-//! ---
+//! Sets the minimum logging level for all modules, if not overwritten with
+//! [`Dispatch::level_for`], to [`Level::Debug`][log::Level::Debug].
 //!
-//! [`.chain(std::io::stdout())`]
+//!
+//! ```
+//! # fern::Dispatch::new()
+//! .chain(std::io::stdout())
+//! # ;
+//! ```
 //!
 //! Add a child to the logger. All messages which pass the filters will be sent
 //! to stdout.
@@ -152,17 +180,25 @@
 //! [`Dispatch::chain`] accepts [`Stdout`], [`Stderr`], [`File`] and other
 //! [`Dispatch`] instances.
 //!
-//! ---
 //!
-//! [`.chain(fern::log_file(...)?)`]
+//! ```
+//! # fern::Dispatch::new()
+//! .chain(fern::log_file("output.log")?)
+//! # ; <Result<(), Box<dyn std::error::Error>>>::Ok(())
+//! ```
 //!
 //! Add a second child sending messages to the file "output.log".
 //!
-//! See [`fern::log_file()`] for more info on file output.
+//! See [`log_file`] for more info on file output.
 //!
-//! ---
 //!
-//! [`.apply()`][`.apply`]
+//! ```
+//! # fern::Dispatch::new()
+//! // ...
+//! .apply()
+//! # ;
+//! ```
+//!
 //!
 //! Consume the configuration and instantiate it as the current runtime global
 //! logger.
@@ -171,8 +207,8 @@
 //! has already been used this runtime.
 //!
 //! Since the binary crate is the only one ever setting up logging, the
-//! [`apply`] result can be reasonably unwrapped: it's a bug if any crate is
-//! calling this method more than once.
+//! [`Dispatch::apply`] result can be reasonably unwrapped: it's a bug if any
+//! crate is calling this method more than once.
 //!
 //! ---
 //!
@@ -211,7 +247,7 @@
 //!
 //! # More
 //!
-//! The [`Dispatch` documentation] has example usages of each method, and the
+//! The [`Dispatch`] documentation has example usages of each method, and the
 //! [full example program] might be useful for using fern in a larger
 //! application context.
 //!
@@ -223,32 +259,12 @@
 //! See the [meta] module for information on getting logging-within-logging
 //! working correctly.
 //!
-//! [`fern::Dispatch::new()`]: struct.Dispatch.html#method.new
-//! [`.format(|...| ...)`]: struct.Dispatch.html#method.format
-//! [`out.finish(format_args!(...))`]: struct.FormatCallback.html#method.finish
-//! [`.level(log::LevelFilter::Debug)`]: struct.Dispatch.html#method.level
-//! [`Dispatch::chain`]: struct.Dispatch.html#method.chain
-//! [`.chain(std::io::stdout())`]: struct.Dispatch.html#method.chain
-//! [`Stdout`]: https://doc.rust-lang.org/std/io/struct.Stdout.html
-//! [`Stderr`]: https://doc.rust-lang.org/std/io/struct.Stderr.html
-//! [`File`]: https://doc.rust-lang.org/std/fs/struct.File.html
-//! [`Dispatch`]: struct.Dispatch.html
-//! [`.chain(fern::log_file(...)?)`]: struct.Dispatch.html#method.chain
-//! [`fern::log_file()`]: fn.log_file.html
-//! [`.apply`]: struct.Dispatch.html#method.apply
-//! [`format_args!()`]: https://doc.rust-lang.org/std/macro.format_args.html
-//! [`println!()`]: https://doc.rust-lang.org/std/macro.println.html
-//! [`std::fmt`]: https://doc.rust-lang.org/std/fmt/
-//! [`chrono`]: https://github.com/chronotope/chrono
-//! [`Dispatch` documentation]: struct.Dispatch.html
+//! [`Stdout`]: std::io::Stdout
+//! [`Stderr`]: std::io::Stderr
+//! [`File`]: std::fs::File
 //! [full example program]: https://github.com/daboross/fern/tree/fern-0.6.1/examples/cmd-program.rs
 //! [syslog full example program]: https://github.com/daboross/fern/tree/fern-0.6.1/examples/syslog.rs
-//! [`apply`]: struct.Dispatch.html#method.apply
-//! [colors]: colors/index.html
-//! [syslog]: syslog/index.html
-//! [meta]: meta/index.html
-//! [format_rfc3339_seconds]: https://docs.rs/humantime/2/humantime/fn.format_rfc3339_seconds.html
-//! [`humantime`]: https://docs.rs/humantime/2/
+//! [`humantime::format_rfc3339_seconds`]: https://docs.rs/humantime/2/humantime/fn.format_rfc3339_seconds.html
 use std::{
     convert::AsRef,
     fmt,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,13 +102,24 @@
 //! ```
 //! # fern::Dispatch::new()
 //! .format(|out, message, record| {
-//!     // ...
+//!     out.finish(format_args!(
+//!         "..."
+//!     ))
 //! })
 //! # ;
 //! ```
 //!
-//! [`Dispatch::format`] sets the formatter of the dispatch, modifying all
-//! messages sent through.
+//! This incantation sets the `Dispatch` format! The closure taking in
+//! `out, message, record` will be called once for each message going through
+//! the dispatch, and the formatted log message will be used for any downstream
+//! consumers.
+//!
+//! Do any work you want in this closure, and then call `out.finish` at the end.
+//! The callback-style result passing with `out.finish(format_args!())` lets us
+//! format without any intermediate string allocation.
+//!
+//! [`format_args!`] has the same format as [`println!`], just returning a
+//! not-yet-written result we can use internally.
 //!
 //! ```
 //! std::time::SystemTime::now()
@@ -131,32 +142,11 @@
 //! RFC3339 looks like `2018-02-14T00:28:07Z`, always using UTC, ignoring system
 //! timezone.
 //!
-//! `humantime` is a nice light dependency, but does only offer this one format.
-//! To do more custom time formatting, I recommend
-//! [`chrono`](https://docs.rs/chrono/) or
-//! [`time`](https://docs.rs/time/).
-//!
-//!
-//! ```
-//! # fern::Dispatch::new().format(|out, message, record| {
-//! out.finish(format_args!(
-//!     # /*
-//!     ...
-//!     # */ ""
-//! ))
-//! # });
-//! ```
-//!
-//! Call the `fern::FormattingCallback` to submit the formatted message.
-//!
-//! This callback-style allows for logging with no intermediate string
-//! allocation!
-//!
-//! [`format_args!`] has the same format as [`println!`], just returning a
-//! not-yet-written result we can use internally.
+//! `humantime` is a nice light dependency, but only offers this one format.
+//! For more custom time formatting, I recommend
+//! [`chrono`](https://docs.rs/chrono/) or [`time`](https://docs.rs/time/).
 //!
 //! Now, back to the [`Dispatch`] methods:
-//!
 //!
 //! ```
 //! # fern::Dispatch::new()
@@ -167,19 +157,17 @@
 //! Sets the minimum logging level for all modules, if not overwritten with
 //! [`Dispatch::level_for`], to [`Level::Debug`][log::Level::Debug].
 //!
-//!
 //! ```
 //! # fern::Dispatch::new()
 //! .chain(std::io::stdout())
 //! # ;
 //! ```
 //!
-//! Add a child to the logger. All messages which pass the filters will be sent
-//! to stdout.
+//! Adds a child to the logger. With this, all messages which pass the filters
+//! will be sent to stdout.
 //!
 //! [`Dispatch::chain`] accepts [`Stdout`], [`Stderr`], [`File`] and other
 //! [`Dispatch`] instances.
-//!
 //!
 //! ```
 //! # fern::Dispatch::new()
@@ -187,10 +175,9 @@
 //! # ; <Result<(), Box<dyn std::error::Error>>>::Ok(())
 //! ```
 //!
-//! Add a second child sending messages to the file "output.log".
+//! Adds a second child sending messages to the file "output.log".
 //!
-//! See [`log_file`] for more info on file output.
-//!
+//! See [`log_file`].
 //!
 //! ```
 //! # fern::Dispatch::new()
@@ -199,16 +186,16 @@
 //! # ;
 //! ```
 //!
-//!
-//! Consume the configuration and instantiate it as the current runtime global
+//! Consumes the configuration and instantiates it as the current runtime global
 //! logger.
 //!
 //! This will fail if and only if `.apply()` or equivalent form another crate
 //! has already been used this runtime.
 //!
-//! Since the binary crate is the only one ever setting up logging, the
-//! [`Dispatch::apply`] result can be reasonably unwrapped: it's a bug if any
-//! crate is calling this method more than once.
+//! Since the binary crate is the only one ever setting up logging, and it's
+//! usually done near the start of `main`, the [`Dispatch::apply`] result can be
+//! reasonably unwrapped: it's a bug if any crate is calling this method more
+//! than once.
 //!
 //! ---
 //!


### PR DESCRIPTION
I've felt this is a bit too cluttered for a while. Fix it up!

I'm only around 60% sure the new one is better. However, it's probably not worse!

This also includes some misc. doc fixes, and moves to intra-doc links that didn't exist when these docs were originally written.