### PR TITLE
Fixes Issue with type public export SharedDispatch from builders module.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,7 +264,7 @@ use std::{
 use std::collections::HashMap;
 
 pub use crate::{
-    builders::{Dispatch, Output, Panic},
+    builders::{Dispatch, Output, Panic, SharedDispatch},
     errors::InitError,
     log_impl::FormatCallback,
 };


### PR DESCRIPTION
This should allow SharedDispatch in builders.rs to be part of the crate..