### PR TITLE
Add syslog v7 support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,6 +62,10 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --features=syslog-7
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
           args: --features=reopen-03
       - uses: actions-rs/cargo@v1
         with:
@@ -103,6 +107,7 @@ jobs:
       - run: cargo run --example syslog3 --features syslog-3
       - run: cargo run --example syslog4 --features syslog-4
       - run: cargo run --example syslog --features syslog-6
+      - run: cargo run --example syslog7 --features syslog-7
   msrv:
     name: MSRV Compatability - fern
     runs-on: ${{ matrix.os }}
@@ -169,6 +174,22 @@ jobs:
           toolchain: 1.67.0
           override: true
       - run: cargo build --features syslog-6
+  msrv_syslog_7:
+    name: MSRV Compatability - fern/syslog-7
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.67.0
+          override: true
+      - run: cargo build --features syslog-7
   fmt_and_clippy:
     name: Optional Lints
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ nb-configuration.xml
 *.iws
 *.sublime-project
 *.sublime-workspace
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,6 @@ reopen-1 = ["reopen1", "libc"]
 meta-logging-in-format = []
 date-based = ["chrono"]
 
-# default = ["syslog-7"]
-
 [dev-dependencies]
 tempfile = "3"
 clap = "2.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ chrono = { version = "0.4", default-features = false, features = ["std", "clock"
 syslog3 = { version = "3", package = "syslog", optional = true }
 syslog4 = { version = "4", package = "syslog", optional = true }
 syslog6 = { version = "6", package = "syslog", optional = true }
+syslog7 = { version = "7", package = "syslog", optional = true }
 reopen1 = { version = "~1", package = "reopen", features = ["signals"], optional = true }
 reopen03 = { version = "^0.3", package = "reopen", optional = true }
 libc = { version = "0.2.58", optional = true }
@@ -35,10 +36,13 @@ libc = { version = "0.2.58", optional = true }
 syslog-3 = ["syslog3"]
 syslog-4 = ["syslog4"]
 syslog-6 = ["syslog6"]
+syslog-7 = ["syslog7"]
 reopen-03 = ["reopen03", "libc"]
 reopen-1 = ["reopen1", "libc"]
 meta-logging-in-format = []
 date-based = ["chrono"]
+
+# default = ["syslog-7"]
 
 [dev-dependencies]
 tempfile = "3"
@@ -59,6 +63,10 @@ required-features = ["colored"]
 [[example]]
 name = "pretty-colored"
 required-features = ["colored"]
+
+[[example]]
+name = "syslog7"
+required-features = ["syslog-7"]
 
 [[example]]
 name = "syslog"

--- a/examples/syslog7.rs
+++ b/examples/syslog7.rs
@@ -1,0 +1,54 @@
+#[cfg(not(windows))]
+// This is necessary because `fern` depends on both version 3, 4 and 6
+use syslog7 as syslog;
+
+#[cfg(not(windows))]
+use log::{debug, info, warn};
+
+#[cfg(not(windows))]
+fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
+    let syslog_fmt = syslog::Formatter3164 {
+        facility: syslog::Facility::LOG_USER,
+        hostname: None,
+        process: "fern-syslog-example".into(),
+        pid: 0,
+    };
+    fern::Dispatch::new()
+        // by default only accept warning messages so as not to spam
+        .level(log::LevelFilter::Warn)
+        // but accept Info if we explicitly mention it
+        .level_for("explicit-syslog", log::LevelFilter::Info)
+        .chain(syslog::unix(syslog_fmt)?)
+        .apply()?;
+
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn main() {
+    setup_logging().expect("failed to initialize logging.");
+
+    // None of this will be shown in the syslog:
+    for i in 0..5 {
+        info!("executing section: {}", i);
+
+        debug!("section {} 1/4 complete.", i);
+
+        debug!("section {} 1/2 complete.", i);
+
+        debug!("section {} 3/4 complete.", i);
+
+        info!("section {} completed!", i);
+    }
+
+    // these two *will* show.
+
+    info!(target: "explicit-syslog", "hello to the syslog! this is rust.");
+
+    warn!("AHHH something's on fire.");
+}
+
+#[cfg(windows)]
+fn main() {
+    panic!("this example does not work on Windows.");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,6 +238,9 @@ use std::{
 #[cfg(all(not(windows), any(feature = "syslog-4", feature = "syslog-6")))]
 use std::collections::HashMap;
 
+#[cfg(all(not(windows), feature = "syslog-7"))]
+use std::collections::BTreeMap;
+
 pub use crate::{
     builders::{Dispatch, Output, Panic},
     errors::InitError,
@@ -291,6 +294,12 @@ type Syslog6Rfc3164Logger = syslog6::Logger<syslog6::LoggerBackend, syslog6::For
 #[cfg(all(not(windows), feature = "syslog-6"))]
 type Syslog6Rfc5424Logger = syslog6::Logger<syslog6::LoggerBackend, syslog6::Formatter5424>;
 
+#[cfg(all(not(windows), feature = "syslog-7"))]
+type Syslog7Rfc3164Logger = syslog7::Logger<syslog7::LoggerBackend, syslog7::Formatter3164>;
+
+#[cfg(all(not(windows), feature = "syslog-7"))]
+type Syslog7Rfc5424Logger = syslog7::Logger<syslog7::LoggerBackend, syslog7::Formatter5424>;
+
 #[cfg(all(not(windows), feature = "syslog-4"))]
 type Syslog4TransformFn =
     dyn Fn(&log::Record) -> (i32, HashMap<String, HashMap<String, String>>, String) + Send + Sync;
@@ -298,6 +307,10 @@ type Syslog4TransformFn =
 #[cfg(all(not(windows), feature = "syslog-6"))]
 type Syslog6TransformFn =
     dyn Fn(&log::Record) -> (u32, HashMap<String, HashMap<String, String>>, String) + Send + Sync;
+
+#[cfg(all(not(windows), feature = "syslog-7"))]
+type Syslog7TransformFn =
+    dyn Fn(&log::Record) -> (u32, BTreeMap<String, BTreeMap<String, String>>, String) + Send + Sync;
 
 /// Convenience method for opening a log file with common options.
 ///


### PR DESCRIPTION
A while back the syslog crate was updated to v7.
This PR adds compatibility with this new version in fern.

Also added `.vscode` to the `.gitignore` and fixed a comment where it mentioned `syslog-4` where it should have been `syslog-6`