### PR TITLE
Bump colored and clap versions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,9 +13,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust:
-          - stable
-          - beta
         os:
           - ubuntu-latest
           - windows-latest
@@ -31,6 +28,7 @@ jobs:
       - run: cargo test
       - run: cargo test --no-default-features
       - run: cargo test --features=colored
+      - run: cargo test --features=colored-3
       - run: cargo test --features=syslog-3
       - run: cargo test --features=syslog-4
       - run: cargo test --features=syslog-6
@@ -54,9 +52,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust:
-          - stable
-          - beta
         toolchain:
           - stable
           - 1.80.0

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
           - windows-latest
         toolchain:
           - stable
-          - 1.70.0
+          - 1.80.0
     steps:
       - uses: actions/checkout@v4
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
@@ -59,7 +59,7 @@ jobs:
           - beta
         toolchain:
           - stable
-          - 1.70.0
+          - 1.80.0
     steps:
       - uses: actions/checkout@v4
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ include = ["Cargo.toml", "src/**/*", "tests/**/*", "examples/**/*", "LICENSE", "
 
 [dependencies]
 log = { version = "0.4", features = ["std"] }
-colored = { version = "3.0", optional = true }
+colored2 = { version = "2.1.0", package = "colored", optional = true }
+colored3 = { version = "3", package = "colored", optional = true }
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"], optional = true }
 
 [target."cfg(not(windows))".dependencies]
@@ -41,6 +42,8 @@ reopen-03 = ["reopen03", "libc"]
 reopen-1 = ["reopen1", "libc"]
 meta-logging-in-format = []
 date-based = ["chrono"]
+colored = ["colored2"]
+colored-3 = ["colored3"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ include = ["Cargo.toml", "src/**/*", "tests/**/*", "examples/**/*", "LICENSE", "
 
 [dependencies]
 log = { version = "0.4", features = ["std"] }
-colored = { version = "2.1.0", optional = true }
+colored = { version = "3.0", optional = true }
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"], optional = true }
 
 [target."cfg(not(windows))".dependencies]
@@ -44,7 +44,7 @@ date-based = ["chrono"]
 
 [dev-dependencies]
 tempfile = "3"
-clap = "2.22"
+clap = "4"
 humantime = "2.1.0"
 
 [[example]]

--- a/examples/cmd-program.rs
+++ b/examples/cmd-program.rs
@@ -2,7 +2,7 @@ use std::{io, time::SystemTime};
 
 use log::{debug, info, trace, warn};
 
-fn setup_logging(verbosity: u64) -> Result<(), fern::InitError> {
+fn setup_logging(verbosity: u8) -> Result<(), fern::InitError> {
     let mut base_config = fern::Dispatch::new();
 
     base_config = match verbosity {
@@ -64,17 +64,17 @@ fn setup_logging(verbosity: u64) -> Result<(), fern::InitError> {
 }
 
 fn main() {
-    let cmd_arguments = clap::App::new("cmd-program")
+    let cmd_arguments = clap::Command::new("cmd-program")
         .arg(
-            clap::Arg::with_name("verbose")
-                .short("v")
+            clap::Arg::new("verbose")
+                .short('v')
                 .long("verbose")
-                .multiple(true)
-                .help("Increases logging verbosity each use for up to 3 times"),
+                .help("Increases logging verbosity each use for up to 3 times")
+                .action(clap::ArgAction::Count),
         )
         .get_matches();
 
-    let verbosity: u64 = cmd_arguments.occurrences_of("verbose");
+    let verbosity = cmd_arguments.get_count("verbose");
 
     setup_logging(verbosity).expect("failed to initialize logging.");
 

--- a/examples/syslog.rs
+++ b/examples/syslog.rs
@@ -1,5 +1,5 @@
 #[cfg(not(windows))]
-// This is necessary because `fern` depends on both version 3 and 4.
+// This is necessary because `fern` depends on multiple versions.
 use syslog6 as syslog;
 
 #[cfg(not(windows))]

--- a/examples/syslog3.rs
+++ b/examples/syslog3.rs
@@ -1,5 +1,5 @@
 #[cfg(not(windows))]
-// This is necessary because `fern` depends on both version 3 and 4.
+// This is necessary because `fern` depends on multiple versions.
 use syslog3 as syslog;
 
 #[cfg(not(windows))]

--- a/examples/syslog4.rs
+++ b/examples/syslog4.rs
@@ -1,5 +1,5 @@
 #[cfg(not(windows))]
-// This is necessary because `fern` depends on both version 3 and 4.
+// This is necessary because `fern` depends on multiple versions.
 use syslog4 as syslog;
 
 #[cfg(not(windows))]

--- a/examples/syslog7.rs
+++ b/examples/syslog7.rs
@@ -1,5 +1,5 @@
 #[cfg(not(windows))]
-// This is necessary because `fern` depends on both version 3, 4 and 6
+// This is necessary because `fern` depends on multiple versions.
 use syslog7 as syslog;
 
 #[cfg(not(windows))]

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -1,7 +1,7 @@
 //! Support for ANSI terminal colors via the colored crate.
 //!
-//! To enable support for colors, add the `"colored"` feature in your
-//! `Cargo.toml`:
+//! To enable support for colors, add the `"colored"` or `"colored-3"`
+//! (version 3, which requires rust 1.80) feature in your `Cargo.toml`:
 //!
 //! ```toml
 //! [dependencies]
@@ -56,7 +56,7 @@
 //! [ex]: https://github.com/daboross/fern/blob/fern-0.7.0/examples/pretty-colored.rs
 use std::fmt;
 
-pub use colored::Color;
+pub use crate::colored::Color;
 use log::Level;
 
 /// Extension crate allowing the use of `.colored` on Levels.
@@ -158,7 +158,7 @@ impl ColoredLevelConfig {
     pub fn new() -> Self {
         #[cfg(windows)]
         {
-            let _ = colored::control::set_virtual_terminal(true);
+            let _ = crate::colored::control::set_virtual_terminal(true);
         }
         Self::default()
     }
@@ -280,7 +280,7 @@ impl ColoredLogLevel for Level {
 #[cfg(test)]
 #[cfg(not(windows))]
 mod test {
-    use colored::{Color::*, Colorize};
+    use crate::colored::{Color::*, Colorize};
 
     use super::WithFgColor;
 
@@ -304,7 +304,7 @@ mod test {
             BrightCyan,
             BrightWhite,
         ] {
-            colored::control::SHOULD_COLORIZE.set_override(true);
+            crate::colored::control::SHOULD_COLORIZE.set_override(true);
             assert_eq!(
                 format!("{}", "test".color(color)),
                 format!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,8 +251,14 @@ mod builders;
 mod errors;
 mod log_impl;
 
-#[cfg(feature = "colored")]
+#[cfg(any(feature = "colored", feature = "colored-3"))]
 pub mod colors;
+#[cfg(feature = "colored")]
+use colored2 as colored;
+
+#[cfg(feature = "colored-3")]
+use colored3 as colored;
+
 #[cfg(all(
     feature = "syslog-3",
     feature = "syslog-4",


### PR DESCRIPTION
Primary purpose is to use the newer colored, but update clap and the corresponding example as well.

Edit: had to bump the version of the tests. colored v3 requires 1.80 (and the clap example 1.74), but MSRV is still 1.60.

Edit (again): ended up with adding an additional feature `colored-3`, because of the big jump in rust verison.

Also removed half of the tests since the `rust` matrix variable is not used.